### PR TITLE
fix: replace binary cover assets with svg placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+/dist
+.DS_Store
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 90
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Tonti
+
+Prototype statique 100% TypeScript (sans React) construit avec esbuild pour la plateforme de cagnottes Tonti.
+
+## Prérequis
+- Node.js 20+
+- npm
+
+## Installation
+```bash
+npm install
+```
+
+## Développement
+```bash
+npm run dev
+```
+Le script lance un serveur esbuild sur http://localhost:4173, regénère le bundle et la feuille de style `src/styles/app.css` à chaque modification.
+
+## Vérifications
+```bash
+npm run lint       # Vérifie le formatage Prettier
+npm run typecheck  # Vérifie les types avec tsc --noEmit
+```
+
+## Build statique
+```bash
+npm run build
+```
+
+Le dossier `dist/` contient la version exportée prête à être servie statiquement (GitHub Pages, Netlify, etc.).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tonti</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Kufi+Arabic:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/src/styles/app.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/app.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tonti",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev.mjs",
+    "build": "node scripts/build.mjs",
+    "lint": "prettier --check .",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "esbuild": "^0.23.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/public/images/cover1.svg
+++ b/public/images/cover1.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Solidarité pour le Rif</title>
+  <desc id="desc">Illustration abstraite en dégradé bleu et doré utilisée comme couverture de cagnotte.</desc>
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="50%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#fbbf24" />
+    </linearGradient>
+    <radialGradient id="glow" cx="70%" cy="25%" r="60%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#fde68a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#gradient)" rx="48" />
+  <circle cx="840" cy="220" r="280" fill="url(#glow)" />
+  <g fill="#f8fafc" font-family="'Inter', 'Arial', sans-serif" font-weight="700" text-anchor="start">
+    <text x="96" y="168" font-size="72">Solidarité</text>
+    <text x="96" y="252" font-size="72">pour le Rif</text>
+    <text x="96" y="348" font-size="32" opacity="0.85">Aidons les familles touchées</text>
+    <text x="96" y="396" font-size="32" opacity="0.85">par les intempéries</text>
+  </g>
+  <g opacity="0.45" stroke="#fef3c7" stroke-width="6" fill="none">
+    <path d="M1080 540c-64-120-188-180-332-144-116 30-216 130-312 174-88 40-176 32-248-40" stroke-linecap="round" />
+  </g>
+</svg>

--- a/public/images/cover2.svg
+++ b/public/images/cover2.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" role="img" aria-labelledby="title desc">
+  <title id="title">Célébration de mariage</title>
+  <desc id="desc">Illustration abstraite dans des tons chauds utilisée comme couverture pour une cagnotte de mariage.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7c3aed" />
+      <stop offset="60%" stop-color="#c026d3" />
+      <stop offset="100%" stop-color="#fb7185" />
+    </linearGradient>
+    <radialGradient id="highlight" cx="30%" cy="30%" r="65%">
+      <stop offset="0%" stop-color="#fdf2f8" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#fdf2f8" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#bg)" rx="48" />
+  <rect x="120" y="120" width="960" height="435" rx="56" fill="rgba(255,255,255,0.08)" />
+  <rect x="180" y="180" width="840" height="315" rx="44" fill="rgba(255,255,255,0.12)" />
+  <circle cx="360" cy="252" r="96" fill="url(#highlight)" />
+  <circle cx="960" cy="180" r="160" fill="rgba(253,242,248,0.35)" />
+  <g fill="#fdf2f8" font-family="'Inter', 'Arial', sans-serif" text-anchor="middle">
+    <text x="600" y="300" font-size="96" font-weight="700">Samia &amp; Youssef</text>
+    <text x="600" y="372" font-size="40" font-weight="500" opacity="0.85">Célébrons leur union</text>
+  </g>
+  <g fill="none" stroke="#fdf2f8" stroke-opacity="0.5" stroke-width="6">
+    <path d="M180 480c120 84 360 84 480 0s360-84 480 0" stroke-linecap="round" />
+  </g>
+  <g fill="#fde68a" opacity="0.75">
+    <circle cx="960" cy="492" r="18" />
+    <circle cx="900" cy="540" r="12" />
+    <circle cx="1020" cy="528" r="10" />
+  </g>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Tonti",
+  "short_name": "Tonti",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0B0F1A",
+  "theme_color": "#0B0F1A",
+  "icons": []
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,24 @@
+const CACHE_NAME = 'tonti-shell-v1';
+const OFFLINE_URL = '/index.html';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll([OFFLINE_URL, '/assets/styles.css', '/assets/main.js']))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return (
+        response ||
+        fetch(event.request).catch(() => {
+          if (event.request.mode === 'navigate') {
+            return caches.match(OFFLINE_URL);
+          }
+          return response;
+        })
+      );
+    })
+  );
+});

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,53 @@
+import { build } from "esbuild";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const outDir = "dist";
+const assetsDir = path.join(outDir, "assets");
+const entryPoint = "src/app.ts";
+const cssSource = "src/styles/app.css";
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(assetsDir, { recursive: true });
+
+async function writeHtml() {
+  const html = await readFile("index.html", "utf-8");
+  const finalHtml = html
+    .replace("/src/app.ts", "/assets/app.js")
+    .replace("/src/styles/app.css", "/assets/app.css");
+  await writeFile(path.join(outDir, "index.html"), finalHtml);
+}
+
+await build({
+  entryPoints: [entryPoint],
+  bundle: true,
+  format: "esm",
+  outfile: path.join(assetsDir, "app.js"),
+  sourcemap: true,
+  minify: true,
+  target: "es2020",
+  define: {
+    "process.env.NODE_ENV": '"production"'
+  },
+  alias: {
+    "@core": path.resolve("src/core"),
+    "@data": path.resolve("src/data"),
+    "@lib": path.resolve("src/lib"),
+    "@ui": path.resolve("src/ui"),
+    "@views": path.resolve("src/views")
+  }
+});
+
+await cp(cssSource, path.join(assetsDir, "app.css"));
+
+try {
+  await cp("public", outDir, { recursive: true });
+} catch (error) {
+  if (error && typeof error === "object" && "code" in error && error.code !== "ENOENT") {
+    throw error;
+  }
+}
+
+await writeHtml();
+
+console.log("Build complete ➜", outDir);

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,78 @@
+import { context } from "esbuild";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { watch } from "node:fs";
+import path from "node:path";
+
+const outDir = "dist";
+const assetsDir = path.join(outDir, "assets");
+const entryPoint = "src/app.ts";
+const cssSource = "src/styles/app.css";
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(assetsDir, { recursive: true });
+
+async function writeHtml() {
+  const html = await readFile("index.html", "utf-8");
+  const finalHtml = html
+    .replace("/src/app.ts", "/assets/app.js")
+    .replace("/src/styles/app.css", "/assets/app.css");
+  await writeFile(path.join(outDir, "index.html"), finalHtml);
+}
+
+async function copyCss() {
+  await cp(cssSource, path.join(assetsDir, "app.css"));
+}
+
+await writeHtml();
+await copyCss();
+try {
+  await cp("public", outDir, { recursive: true });
+} catch (error) {
+  if (error && typeof error === "object" && "code" in error && error.code !== "ENOENT") {
+    throw error;
+  }
+}
+
+const cssWatcher = watch(cssSource, { persistent: true }, async (eventType) => {
+  if (eventType === "change" || eventType === "rename") {
+    try {
+      await copyCss();
+      console.log("✔ CSS updated");
+    } catch (error) {
+      console.error("✖ CSS copy failed", error);
+    }
+  }
+});
+
+const ctx = await context({
+  entryPoints: [entryPoint],
+  bundle: true,
+  format: "esm",
+  outfile: path.join(assetsDir, "app.js"),
+  sourcemap: true,
+  target: "es2020",
+  define: {
+    "process.env.NODE_ENV": '"development"'
+  },
+  alias: {
+    "@core": path.resolve("src/core"),
+    "@data": path.resolve("src/data"),
+    "@lib": path.resolve("src/lib"),
+    "@ui": path.resolve("src/ui"),
+    "@views": path.resolve("src/views")
+  }
+});
+
+await ctx.watch();
+const server = await ctx.serve({ servedir: outDir, host: "0.0.0.0", port: 4173 });
+
+console.log(`Dev server ready on http://localhost:${server.port}`);
+
+const shutdown = async () => {
+  cssWatcher.close();
+  await ctx.dispose();
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,264 @@
+import { state, subscribe, setPath, initHistory, setLocale } from "@core/state";
+import { messages, LOCALES, type Locale, type LocaleMessages } from "@lib/i18n";
+import { configureToasts } from "@ui/toast";
+import { clearChildren } from "@ui/dom";
+import { renderHome } from "@views/home";
+import { renderHow } from "@views/how";
+import { renderFaq } from "@views/faq";
+import { renderHelp } from "@views/help";
+import { renderLegalPage } from "@views/legalPage";
+import { renderLogin } from "@views/login";
+import { renderCagnotte } from "@views/cagnotte";
+import { renderCreate } from "@views/create";
+import { renderNotFound } from "@views/notFound";
+
+const root = document.getElementById("app");
+if (!root) {
+  throw new Error("Unable to locate #app container");
+}
+
+const shell = document.createElement("div");
+shell.className = "shell";
+root.appendChild(shell);
+
+const header = document.createElement("header");
+header.className = "site-header";
+shell.appendChild(header);
+
+const logo = document.createElement("a");
+logo.className = "logo";
+logo.textContent = "Tonti";
+header.appendChild(logo);
+
+const nav = document.createElement("nav");
+nav.className = "site-nav";
+const navList = document.createElement("ul");
+navList.className = "nav-list";
+nav.appendChild(navList);
+header.appendChild(nav);
+
+const localeSwitch = document.createElement("div");
+localeSwitch.className = "locale-switch";
+header.appendChild(localeSwitch);
+
+const main = document.createElement("main");
+main.className = "main";
+shell.appendChild(main);
+
+const footer = document.createElement("footer");
+footer.className = "site-footer";
+shell.appendChild(footer);
+
+const footerLinks = document.createElement("div");
+footerLinks.className = "footer-links";
+footer.appendChild(footerLinks);
+
+const footerNote = document.createElement("p");
+footerNote.className = "footer-note";
+footer.appendChild(footerNote);
+
+const navConfig: { key: keyof LocaleMessages["nav"]; relativePath: string; element: HTMLAnchorElement }[] = [
+  { key: "home", relativePath: "/", element: document.createElement("a") },
+  { key: "create", relativePath: "/cagnotte/creer", element: document.createElement("a") },
+  { key: "how", relativePath: "/comment-ca-marche", element: document.createElement("a") },
+  { key: "faq", relativePath: "/faq", element: document.createElement("a") },
+  { key: "help", relativePath: "/aide", element: document.createElement("a") },
+  { key: "legal", relativePath: "/mentions-legales", element: document.createElement("a") }
+];
+
+for (const item of navConfig) {
+  const listItem = document.createElement("li");
+  item.element.setAttribute("data-route", item.relativePath);
+  listItem.appendChild(item.element);
+  navList.appendChild(listItem);
+}
+
+const footerConfig: { key: keyof LocaleMessages["footer"]; relativePath: string; element: HTMLAnchorElement }[] = [
+  { key: "legal", relativePath: "/mentions-legales", element: document.createElement("a") },
+  { key: "privacy", relativePath: "/politique-confidentialite", element: document.createElement("a") },
+  { key: "terms", relativePath: "/cgu", element: document.createElement("a") }
+];
+
+for (const item of footerConfig) {
+  item.element.setAttribute("data-route", item.relativePath);
+  footerLinks.appendChild(item.element);
+}
+
+const localeButtons = new Map<Locale, HTMLButtonElement>();
+(["fr", "ar"] as const).forEach((locale) => {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "locale-button";
+  button.dataset.switchLocale = locale;
+  button.setAttribute("aria-label", LOCALES[locale].label);
+  localeButtons.set(locale, button);
+  localeSwitch.appendChild(button);
+});
+
+function parsePath(pathname: string): { locale: Locale; relativePath: string } {
+  if (pathname === "/ar" || pathname.startsWith("/ar/")) {
+    const remainder = pathname.slice(3) || "/";
+    return { locale: "ar", relativePath: remainder.startsWith("/") ? remainder : `/${remainder}` };
+  }
+  return { locale: "fr", relativePath: pathname || "/" };
+}
+
+function localizePath(locale: Locale, relativePath: string): string {
+  const normalized = relativePath.startsWith("/") ? relativePath : `/${relativePath}`;
+  if (locale === "ar") {
+    return normalized === "/" ? "/ar" : `/ar${normalized}`;
+  }
+  return normalized === "/" ? "/" : normalized;
+}
+
+function updateHeader(locale: Locale, localeMessages: LocaleMessages, relativePath: string) {
+  logo.textContent = locale === "ar" ? "تونتي" : "Tonti";
+  const localizedHome = localizePath(locale, "/");
+  logo.href = localizedHome;
+  logo.setAttribute("data-route", localizedHome);
+
+  navConfig.forEach((item) => {
+    const text = localeMessages.nav[item.key];
+    item.element.textContent = text;
+    const href = localizePath(locale, item.relativePath);
+    item.element.href = href;
+    item.element.dataset.route = href;
+    if (relativePath === item.relativePath) {
+      item.element.setAttribute("aria-current", "page");
+    } else {
+      item.element.removeAttribute("aria-current");
+    }
+  });
+
+  localeButtons.forEach((button, key) => {
+    button.textContent = LOCALES[key].label;
+    button.setAttribute("aria-label", LOCALES[key].label);
+    button.ariaPressed = key === locale ? "true" : "false";
+    if (key === locale) {
+      button.setAttribute("aria-current", "true");
+    } else {
+      button.removeAttribute("aria-current");
+    }
+  });
+}
+
+function updateFooter(locale: Locale, localeMessages: LocaleMessages) {
+  footerConfig.forEach((item) => {
+    item.element.textContent = localeMessages.footer[item.key];
+    const href = localizePath(locale, item.relativePath);
+    item.element.href = href;
+    item.element.dataset.route = href;
+  });
+  const year = new Date().getFullYear();
+  footerNote.textContent = locale === "ar" ? `${year} © تونتي` : `${year} © Tonti`;
+}
+
+function renderRoute(locale: Locale, localeMessages: LocaleMessages, relativePath: string): HTMLElement {
+  if (relativePath === "/") {
+    return renderHome(localeMessages, locale);
+  }
+  if (relativePath === "/comment-ca-marche") {
+    return renderHow(localeMessages);
+  }
+  if (relativePath === "/faq") {
+    return renderFaq(localeMessages);
+  }
+  if (relativePath === "/aide") {
+    return renderHelp(localeMessages);
+  }
+  if (relativePath === "/cagnotte/creer") {
+    return renderCreate(localeMessages, locale);
+  }
+  if (relativePath.startsWith("/cagnotte/")) {
+    const slug = relativePath.split("/")[2] ?? "";
+    return renderCagnotte(localeMessages, locale, slug);
+  }
+  if (relativePath === "/auth/login") {
+    return renderLogin(localeMessages);
+  }
+  if (relativePath === "/mentions-legales") {
+    return renderLegalPage(localeMessages, "legal");
+  }
+  if (relativePath === "/politique-confidentialite") {
+    return renderLegalPage(localeMessages, "privacy");
+  }
+  if (relativePath === "/cgu") {
+    return renderLegalPage(localeMessages, "terms");
+  }
+  return renderNotFound(localeMessages, locale);
+}
+
+function computePageTitle(localeMessages: LocaleMessages, relativePath: string): string | null {
+  if (relativePath === "/") return localeMessages.nav.home;
+  if (relativePath === "/comment-ca-marche") return localeMessages.nav.how;
+  if (relativePath === "/faq") return localeMessages.nav.faq;
+  if (relativePath === "/aide") return localeMessages.nav.help;
+  if (relativePath === "/cagnotte/creer") return localeMessages.nav.create;
+  if (relativePath.startsWith("/cagnotte/")) return localeMessages.cagnotte.detailsTitle;
+  if (relativePath === "/auth/login") return localeMessages.login.title;
+  if (relativePath === "/mentions-legales") return localeMessages.footer.legal;
+  if (relativePath === "/politique-confidentialite") return localeMessages.footer.privacy;
+  if (relativePath === "/cgu") return localeMessages.footer.terms;
+  return localeMessages.notFound.title;
+}
+
+function renderApp() {
+  const parsed = parsePath(state.path);
+  if (state.locale !== parsed.locale) {
+    setLocale(parsed.locale);
+    return;
+  }
+
+  const localeMessages = messages[state.locale];
+  configureToasts(localeMessages);
+  updateHeader(state.locale, localeMessages, parsed.relativePath);
+  updateFooter(state.locale, localeMessages);
+
+  clearChildren(main);
+  const view = renderRoute(state.locale, localeMessages, parsed.relativePath);
+  main.appendChild(view);
+
+  const baseTitle = state.locale === "fr" ? "Tonti" : "تونتي";
+  const suffix = computePageTitle(localeMessages, parsed.relativePath);
+  document.title = suffix ? `${baseTitle} – ${suffix}` : baseTitle;
+}
+
+subscribe(renderApp);
+initHistory();
+
+history.replaceState({ path: window.location.pathname }, "", window.location.pathname);
+state.path = window.location.pathname;
+renderApp();
+
+function handleDocumentClick(event: MouseEvent) {
+  const target = event.target as HTMLElement;
+  const localeButton = target.closest<HTMLButtonElement>("[data-switch-locale]");
+  if (localeButton) {
+    event.preventDefault();
+    const next = localeButton.dataset.switchLocale as Locale | undefined;
+    if (!next) return;
+    const parsed = parsePath(state.path);
+    if (parsed.locale === next) return;
+    const nextPath = localizePath(next, parsed.relativePath);
+    if (nextPath !== state.path) {
+      setPath(nextPath);
+    }
+    return;
+  }
+
+  const anchor = target.closest<HTMLAnchorElement>("a[data-route]");
+  if (anchor) {
+    const route = anchor.dataset.route ?? anchor.getAttribute("href");
+    if (!route) return;
+    const url = new URL(route, window.location.origin);
+    if (url.origin !== window.location.origin) {
+      return;
+    }
+    event.preventDefault();
+    if (url.pathname !== state.path) {
+      setPath(url.pathname);
+    }
+  }
+}
+
+document.addEventListener("click", handleDocumentClick);

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -1,0 +1,65 @@
+import { LOCALES, type Locale } from "@lib/i18n";
+
+type Listener = () => void;
+
+type AppState = {
+  locale: Locale;
+  path: string;
+};
+
+const listeners: Listener[] = [];
+
+export const state: AppState = {
+  locale: "fr",
+  path: "/"
+};
+
+export function subscribe(listener: Listener): () => void {
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index >= 0) {
+      listeners.splice(index, 1);
+    }
+  };
+}
+
+function notify() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function setLocale(next: Locale) {
+  if (state.locale === next) return;
+  state.locale = next;
+  const metadata = LOCALES[next];
+  const html = document.documentElement;
+  html.lang = next;
+  html.dir = metadata.dir;
+  if (next === "ar") {
+    html.classList.add("rtl");
+  } else {
+    html.classList.remove("rtl");
+  }
+  notify();
+}
+
+export function setPath(path: string, replace = false) {
+  if (state.path === path) return;
+  state.path = path;
+  if (replace) {
+    history.replaceState({ path }, "", path);
+  } else {
+    history.pushState({ path }, "", path);
+  }
+  notify();
+}
+
+export function initHistory() {
+  window.addEventListener("popstate", (event) => {
+    const nextPath = typeof event.state?.path === "string" ? event.state.path : window.location.pathname;
+    state.path = nextPath;
+    notify();
+  });
+}

--- a/src/data/cagnottes.ts
+++ b/src/data/cagnottes.ts
@@ -1,0 +1,71 @@
+import type { CategoryId } from "./categories";
+
+export type Contribution = {
+  nom: string;
+  montantMAD: number;
+  date: string;
+  statut: "completed" | "pending";
+};
+
+export type Organisateur = { id: string; nom: string };
+
+export type Beneficiaire = { nom: string };
+
+export type Cagnotte = {
+  id: string;
+  titre: string;
+  description: string;
+  categorie: CategoryId;
+  organisateur: Organisateur;
+  beneficiaire: Beneficiaire;
+  objectifMAD: number;
+  collecteMAD: number;
+  participants: number;
+  dateFin: string;
+  visibilite: "publique" | "privee" | "non-listee";
+  imageCover: string;
+  historique: Contribution[];
+  statut: "ouverte" | "close";
+};
+
+export const cagnottes: Cagnotte[] = [
+  {
+    id: "soutien-rif",
+    titre: "Solidarité pour le Rif",
+    description: "Aidons les familles touchées par les intempéries dans le Rif.",
+    categorie: "solidarite",
+    organisateur: { id: "u1", nom: "Association Rif Solidaire" },
+    beneficiaire: { nom: "Familles du Rif" },
+    objectifMAD: 50000,
+    collecteMAD: 32400,
+    participants: 268,
+    dateFin: "2024-12-31",
+    visibilite: "publique",
+    imageCover: "/images/cover1.svg",
+    historique: [
+      { nom: "Nadia", montantMAD: 500, date: "2024-06-02", statut: "completed" },
+      { nom: "Anonyme", montantMAD: 200, date: "2024-06-02", statut: "completed" },
+      { nom: "Youssef", montantMAD: 150, date: "2024-06-01", statut: "completed" }
+    ],
+    statut: "ouverte"
+  },
+  {
+    id: "mariage-samia-youssef",
+    titre: "Mariage de Samia & Youssef",
+    description: "Une cagnotte pour célébrer l'union de Samia et Youssef à Fès.",
+    categorie: "mariage",
+    organisateur: { id: "u2", nom: "Amis de Samia" },
+    beneficiaire: { nom: "Samia & Youssef" },
+    objectifMAD: 20000,
+    collecteMAD: 9600,
+    participants: 84,
+    dateFin: "2024-09-15",
+    visibilite: "publique",
+    imageCover: "/images/cover2.svg",
+    historique: [
+      { nom: "Karim", montantMAD: 300, date: "2024-06-01", statut: "completed" },
+      { nom: "Anonyme", montantMAD: 150, date: "2024-05-30", statut: "completed" }
+    ],
+    statut: "ouverte"
+  }
+];

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,0 +1,16 @@
+export type CategoryId = "aid" | "mariage" | "naissance" | "solidarite" | "anniversaire" | "autre";
+
+export type Category = {
+  id: CategoryId;
+  label: { fr: string; ar: string };
+  icon: string;
+};
+
+export const categories: Category[] = [
+  { id: "aid", label: { fr: "Aïd", ar: "عيد" }, icon: "🌙" },
+  { id: "mariage", label: { fr: "Mariage", ar: "زفاف" }, icon: "💍" },
+  { id: "naissance", label: { fr: "Naissance", ar: "مولود" }, icon: "👶" },
+  { id: "solidarite", label: { fr: "Solidarité", ar: "تضامن" }, icon: "🤝" },
+  { id: "anniversaire", label: { fr: "Anniversaire", ar: "عيد ميلاد" }, icon: "🎂" },
+  { id: "autre", label: { fr: "Autre", ar: "أخرى" }, icon: "✨" }
+];

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,9 @@
+export const MAD_FORMATTER = new Intl.NumberFormat("fr-MA", {
+  style: "currency",
+  currency: "MAD",
+  maximumFractionDigits: 0
+});
+
+export function formatMAD(value: number): string {
+  return MAD_FORMATTER.format(value);
+}

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,54 @@
+import type { Locale } from "./i18n";
+
+function ensureDate(value: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return new Date();
+  }
+  return parsed;
+}
+
+const phrases = {
+  fr: {
+    seconds: "à l'instant",
+    minute: "il y a une minute",
+    minutes: (value: number) => `il y a ${value} minutes`,
+    hour: "il y a une heure",
+    hours: (value: number) => `il y a ${value} heures`,
+    day: "il y a un jour",
+    days: (value: number) => `il y a ${value} jours`
+  },
+  ar: {
+    seconds: "الآن",
+    minute: "منذ دقيقة",
+    minutes: (value: number) => `منذ ${value} دقيقة`,
+    hour: "منذ ساعة",
+    hours: (value: number) => `منذ ${value} ساعة`,
+    day: "منذ يوم",
+    days: (value: number) => `منذ ${value} يوم`
+  }
+};
+
+export function formatRelative(date: string, locale: Locale = "fr"): string {
+  const target = ensureDate(date);
+  const now = new Date();
+  const diffMs = Math.max(now.getTime() - target.getTime(), 0);
+  const diffMinutes = Math.round(diffMs / 60000);
+  const diffHours = Math.round(diffMinutes / 60);
+  const diffDays = Math.round(diffHours / 24);
+  const text = phrases[locale];
+
+  if (diffMinutes <= 1) return text.seconds;
+  if (diffMinutes < 60) return text.minutes(diffMinutes);
+  if (diffHours === 1) return text.hour;
+  if (diffHours < 24) return text.hours(diffHours);
+  if (diffDays === 1) return text.day;
+  return text.days(diffDays);
+}
+
+export function daysRemaining(date: string): number {
+  const target = ensureDate(date);
+  const now = new Date();
+  const diffMs = target.getTime() - now.getTime();
+  return Math.max(Math.ceil(diffMs / (1000 * 60 * 60 * 24)), 0);
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,460 @@
+export type Locale = "fr" | "ar";
+
+export const LOCALES: Record<Locale, { label: string; dir: "ltr" | "rtl" }> = {
+  fr: { label: "Français", dir: "ltr" },
+  ar: { label: "العربية", dir: "rtl" }
+};
+
+export type StepOption = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type LocaleMessages = {
+  nav: {
+    home: string;
+    create: string;
+    how: string;
+    faq: string;
+    help: string;
+    legal: string;
+  };
+  footer: {
+    legal: string;
+    privacy: string;
+    terms: string;
+  };
+  home: {
+    heroTitle: string;
+    heroSubtitle: string;
+    heroCta: string;
+    legalHeading: string;
+    legalDescription: string;
+    categoriesTitle: string;
+    featuredTitle: string;
+    featuredCta: string;
+    cardCollected: string;
+    cardGoal: string;
+    cardDaysLeft: string;
+    cardView: string;
+  };
+  create: {
+    title: string;
+    description: string;
+    steps: StepOption[];
+    descriptionStep: {
+      titleLabel: string;
+      titlePlaceholder: string;
+      descriptionLabel: string;
+      descriptionPlaceholder: string;
+      categoryLabel: string;
+    };
+    illustrationStep: {
+      intro: string;
+      placeholder: string;
+    };
+    visibilityStep: {
+      intro: string;
+      options: StepOption[];
+    };
+    amountsStep: {
+      goalLabel: string;
+      minLabel: string;
+      feesNotice: string;
+    };
+    invitationsStep: {
+      intro: string;
+      messagePlaceholder: string;
+      note: string;
+    };
+    actions: {
+      skip: string;
+      continue: string;
+    };
+    toasts: {
+      successTitle: string;
+      successDescription: string;
+      errorTitle: string;
+      errorDescription: string;
+    };
+  };
+  how: {
+    title: string;
+    steps: { title: string; description: string }[];
+  };
+  faq: {
+    title: string;
+    items: { question: string; answer: string; defaultOpen?: boolean }[];
+  };
+  help: {
+    title: string;
+    description: string;
+  };
+  legal: { title: string; description: string };
+  privacy: { title: string; description: string };
+  terms: { title: string; description: string };
+  cagnotte: {
+    notFoundTitle: string;
+    notFoundDescription: string;
+    backHome: string;
+    organizerPrefix: string;
+    progressTitle: string;
+    collectedLabel: string;
+    goalLabel: string;
+    daysLeftLabel: string;
+    participateCta: string;
+    recentParticipants: string;
+    participantsCount: string;
+    detailsTitle: string;
+    beneficiaryLabel: string;
+    visibilityLabel: string;
+    statusLabel: string;
+    paymentNote: string;
+    loginTitle: string;
+    loginDescription: string;
+    loginCta: string;
+    visibilityMap: Record<string, string>;
+    statusMap: Record<string, string>;
+  };
+  login: {
+    title: string;
+    emailLabel: string;
+    passwordLabel: string;
+    submit: string;
+    socialNote: string;
+  };
+  toastClose: string;
+  notFound: {
+    title: string;
+    description: string;
+    back: string;
+  };
+};
+
+export const messages: Record<Locale, LocaleMessages> = {
+  fr: {
+    nav: {
+      home: "Accueil",
+      create: "Créer une cagnotte",
+      how: "Comment ça marche",
+      faq: "FAQ",
+      help: "Aide",
+      legal: "Mentions légales"
+    },
+    footer: {
+      legal: "Mentions légales",
+      privacy: "Politique de confidentialité",
+      terms: "CGU"
+    },
+    home: {
+      heroTitle: "Tonti, la cagnotte digitale des Marocains",
+      heroSubtitle:
+        "Créez et partagez vos cagnottes en toute transparence pour soutenir vos proches au Maroc et à l'étranger.",
+      heroCta: "Lancer ma cagnotte",
+      legalHeading: "Cadre légal marocain",
+      legalDescription:
+        "Tonti est une plateforme de financement collaboratif en cours d'homologation. Les collectes sont simulées et ne représentent pas un service de paiement effectif.",
+      categoriesTitle: "Catégories populaires",
+      featuredTitle: "Cagnottes mises en avant",
+      featuredCta: "Créer une cagnotte",
+      cardCollected: "Collecté",
+      cardGoal: "Objectif",
+      cardDaysLeft: "Jours restants",
+      cardView: "Voir la cagnotte"
+    },
+    create: {
+      title: "Créer une cagnotte",
+      description: "Simulez la création d'une cagnotte conforme au cadre marocain. Les paiements seront activés prochainement.",
+      steps: [
+        { id: "description", label: "Description", description: "Titre, objectif et catégorie" },
+        { id: "illustration", label: "Illustration", description: "Image de couverture" },
+        { id: "visibility", label: "Visibilité", description: "Contrôlez qui peut participer" },
+        { id: "amounts", label: "Montants", description: "Objectif et contributions" },
+        { id: "invitations", label: "Invitations", description: "Message de partage" }
+      ],
+      descriptionStep: {
+        titleLabel: "Titre",
+        titlePlaceholder: "Mariage de Samia & Youssef",
+        descriptionLabel: "Description",
+        descriptionPlaceholder: "Décrivez l'histoire de votre cagnotte...",
+        categoryLabel: "Catégorie"
+      },
+      illustrationStep: {
+        intro: "Ajoutez une image 16:9 pour illustrer votre cagnotte.",
+        placeholder: "Glissez-déposez votre visuel (mock)"
+      },
+      visibilityStep: {
+        intro: "Choisissez la visibilité",
+        options: [
+          { id: "publique", label: "Publique", description: "Accessible à tous" },
+          { id: "privee", label: "Privée", description: "Accès via un code" },
+          { id: "non-listee", label: "Non listée", description: "Lien direct uniquement" }
+        ]
+      },
+      amountsStep: {
+        goalLabel: "Objectif (MAD)",
+        minLabel: "Don suggéré minimum",
+        feesNotice:
+          "Les frais de service seront communiqués prochainement. Aucune transaction réelle n'est opérée via Tonti pour le moment."
+      },
+      invitationsStep: {
+        intro: "Préparez votre message de partage",
+        messagePlaceholder: "Rejoignez ma cagnotte sur Tonti !",
+        note: "Import de contacts et partage par QR code disponibles prochainement. Copiez/collez ce message pour prévenir vos proches."
+      },
+      actions: {
+        skip: "Ignorer",
+        continue: "Sauvegarder & continuer"
+      },
+      toasts: {
+        successTitle: "Cagnotte sauvegardée",
+        successDescription: "Nous vous contacterons dès l'ouverture des paiements.",
+        errorTitle: "Complétez les informations",
+        errorDescription: "Vérifiez le formulaire"
+      }
+    },
+    how: {
+      title: "Comment ça marche",
+      steps: [
+        { title: "1. Créez votre cagnotte", description: "Définissez un titre, une description et une catégorie pour contextualiser." },
+        { title: "2. Personnalisez", description: "Ajoutez une illustration et choisissez la visibilité adaptée à votre cercle." },
+        { title: "3. Partagez", description: "Diffusez le lien sécurisé auprès de vos proches et suivez les contributions." }
+      ]
+    },
+    faq: {
+      title: "Questions fréquentes",
+      items: [
+        {
+          question: "Tonti gère-t-il les paiements ?",
+          answer: "Les paiements sont simulés pour le prototype. L'intégration PSP est en cours de conformité.",
+          defaultOpen: true
+        },
+        {
+          question: "La plateforme est-elle conforme au cadre marocain ?",
+          answer: "Oui, le wording et les mentions légales respectent le projet de loi sur le financement collaboratif."
+        }
+      ]
+    },
+    help: {
+      title: "Aide",
+      description: "Besoin d'assistance ? Contactez-nous sur support@tonti.ma ou consultez la FAQ pour une réponse immédiate."
+    },
+    legal: {
+      title: "Mentions légales",
+      description: "Ce contenu est un placeholder conforme au cadre marocain du financement collaboratif."
+    },
+    privacy: {
+      title: "Politique de confidentialité",
+      description:
+        "Ce contenu présente les engagements de Tonti en matière de protection des données à caractère personnel dans le cadre marocain."
+    },
+    terms: {
+      title: "Conditions générales d'utilisation",
+      description: "Cette page décrit les règles d'utilisation du service Tonti conformément au droit marocain."
+    },
+    cagnotte: {
+      notFoundTitle: "Cagnotte introuvable",
+      notFoundDescription: "La cagnotte recherchée n'existe plus ou a été archivée.",
+      backHome: "Retour à l'accueil",
+      organizerPrefix: "Organisé par",
+      progressTitle: "Progression",
+      collectedLabel: "Collecté",
+      goalLabel: "Objectif",
+      daysLeftLabel: "Jours restants",
+      participateCta: "Je participe (mock)",
+      recentParticipants: "Participants récents",
+      participantsCount: "{count} participants",
+      detailsTitle: "Détails",
+      beneficiaryLabel: "Bénéficiaire",
+      visibilityLabel: "Visibilité",
+      statusLabel: "Statut",
+      paymentNote: "Les paiements par carte, virement et cash seront intégrés prochainement.",
+      loginTitle: "Connexion",
+      loginDescription: "Connectez-vous pour suivre vos contributions.",
+      loginCta: "Ouvrir la modale de connexion",
+      visibilityMap: {
+        publique: "Publique",
+        privee: "Privée",
+        "non-listee": "Non listée"
+      },
+      statusMap: {
+        ouverte: "Ouverte",
+        close: "Clôturée"
+      }
+    },
+    login: {
+      title: "Connexion",
+      emailLabel: "Email",
+      passwordLabel: "Mot de passe",
+      submit: "Se connecter",
+      socialNote: "Connexion sociale disponible prochainement."
+    },
+    toastClose: "Fermer",
+    notFound: {
+      title: "Page introuvable",
+      description: "La page demandée n'existe pas ou n'est plus disponible.",
+      back: "Retour à l'accueil"
+    }
+  },
+  ar: {
+    nav: {
+      home: "الرئيسية",
+      create: "إنشاء حملة",
+      how: "كيف تعمل",
+      faq: "الأسئلة الشائعة",
+      help: "مساعدة",
+      legal: "إشعارات قانونية"
+    },
+    footer: {
+      legal: "إشعارات قانونية",
+      privacy: "سياسة الخصوصية",
+      terms: "الشروط"
+    },
+    home: {
+      heroTitle: "تونتي، الحملة الرقمية للمغاربة",
+      heroSubtitle: "أنشئ وشارك حملاتك بكل شفافية لدعم أحبائك في المغرب وخارجه.",
+      heroCta: "أنشئ حملتي",
+      legalHeading: "إطار قانوني مغربي",
+      legalDescription: "تونتي منصة تمويل تعاوني قيد الاعتماد. المعاملات محاكاة ولا تمثل خدمة دفع فعلية.",
+      categoriesTitle: "الفئات",
+      featuredTitle: "حملات مميزة",
+      featuredCta: "أنشئ حملة",
+      cardCollected: "المبلغ المحصل",
+      cardGoal: "الهدف",
+      cardDaysLeft: "الأيام المتبقية",
+      cardView: "عرض الحملة"
+    },
+    create: {
+      title: "إنشاء حملة",
+      description: "هذه تجربة لإنشاء حملة متوافقة مع الإطار المغربي. سيتم تفعيل المدفوعات لاحقًا.",
+      steps: [
+        { id: "description", label: "الوصف", description: "العنوان، الهدف والفئة" },
+        { id: "illustration", label: "الصورة", description: "صورة الغلاف" },
+        { id: "visibility", label: "الظهور", description: "تحكم بمن يمكنه المشاركة" },
+        { id: "amounts", label: "المبالغ", description: "الهدف والمساهمات" },
+        { id: "invitations", label: "الدعوات", description: "رسالة المشاركة" }
+      ],
+      descriptionStep: {
+        titleLabel: "العنوان",
+        titlePlaceholder: "حملة زفاف سامية ويوسف",
+        descriptionLabel: "الوصف",
+        descriptionPlaceholder: "اشرح قصة حملتك...",
+        categoryLabel: "الفئة"
+      },
+      illustrationStep: {
+        intro: "أضف صورة بنسبة 16:9 لتمثيل حملتك.",
+        placeholder: "اسحب وأفلت الصورة (محاكاة)"
+      },
+      visibilityStep: {
+        intro: "اختر مستوى الظهور",
+        options: [
+          { id: "publique", label: "عامة", description: "متاحة للجميع" },
+          { id: "privee", label: "خاصة", description: "ولوج عبر رمز" },
+          { id: "non-listee", label: "غير مدرجة", description: "رابط مباشر فقط" }
+        ]
+      },
+      amountsStep: {
+        goalLabel: "الهدف (درهم)",
+        minLabel: "الحد الأدنى المقترح",
+        feesNotice: "سيتم توضيح رسوم الخدمة لاحقًا. لا تتم أي معاملة حقيقية عبر تونتي حاليًا."
+      },
+      invitationsStep: {
+        intro: "حضّر رسالة المشاركة",
+        messagePlaceholder: "انضموا إلى حملتي على تونتي!",
+        note: "إمكانية استيراد جهات الاتصال ومشاركة رمز QR قريبًا. انسخ الرسالة لإبلاغ المقربين."
+      },
+      actions: {
+        skip: "تخطي",
+        continue: "حفظ ومتابعة"
+      },
+      toasts: {
+        successTitle: "تم حفظ الحملة",
+        successDescription: "سنتواصل معك فور فتح المدفوعات.",
+        errorTitle: "أكمل المعلومات",
+        errorDescription: "تحقق من الحقول"
+      }
+    },
+    how: {
+      title: "كيف تعمل",
+      steps: [
+        { title: "١. أنشئ حملتك", description: "حدد عنواناً ووصفاً وفئة لتوضيح سياق الحملة." },
+        { title: "٢. خصص", description: "أضف صورة واختر مستوى الظهور الملائم لدائرتك." },
+        { title: "٣. شارك", description: "شارك الرابط الآمن مع أحبائك وتابع المساهمات." }
+      ]
+    },
+    faq: {
+      title: "الأسئلة الشائعة",
+      items: [
+        {
+          question: "هل تدير تونتي المدفوعات؟",
+          answer: "المدفوعات محاكاة في هذا النموذج الأولي. تكامل مزود الخدمة قيد الامتثال.",
+          defaultOpen: true
+        },
+        {
+          question: "هل المنصة متوافقة مع الإطار المغربي؟",
+          answer: "نعم، تمت مواءمة المحتوى والعبارات القانونية مع مشروع قانون التمويل التعاوني."
+        }
+      ]
+    },
+    help: {
+      title: "مساعدة",
+      description: "هل تحتاج إلى دعم؟ راسلنا على support@tonti.ma أو تصفح قسم الأسئلة الشائعة."
+    },
+    legal: {
+      title: "إشعارات قانونية",
+      description: "هذا المحتوى تمهيدي ومتوافق مع الإطار المغربي للتمويل التعاوني."
+    },
+    privacy: {
+      title: "سياسة الخصوصية",
+      description: "يعرض هذا المحتوى التزامات تونتي بحماية المعطيات الشخصية وفق التشريع المغربي."
+    },
+    terms: {
+      title: "الشروط العامة للاستخدام",
+      description: "تصف هذه الصفحة قواعد استخدام خدمة تونتي بما يتماشى مع القانون المغربي."
+    },
+    cagnotte: {
+      notFoundTitle: "الحملة غير متوفرة",
+      notFoundDescription: "الحملة المطلوبة غير موجودة أو تم أرشفتها.",
+      backHome: "العودة إلى الرئيسية",
+      organizerPrefix: "بإدارة",
+      progressTitle: "التقدم",
+      collectedLabel: "المبلغ المحصل",
+      goalLabel: "الهدف",
+      daysLeftLabel: "الأيام المتبقية",
+      participateCta: "أشارك (محاكاة)",
+      recentParticipants: "مساهمات حديثة",
+      participantsCount: "{count} مساهم",
+      detailsTitle: "تفاصيل",
+      beneficiaryLabel: "المستفيد",
+      visibilityLabel: "الظهور",
+      statusLabel: "الحالة",
+      paymentNote: "سيتم دمج وسائل الدفع المغربية قريبًا.",
+      loginTitle: "تسجيل الدخول",
+      loginDescription: "سجل الدخول لمتابعة مساهماتك.",
+      loginCta: "افتح نافذة تسجيل الدخول",
+      visibilityMap: {
+        publique: "عامة",
+        privee: "خاصة",
+        "non-listee": "غير مدرجة"
+      },
+      statusMap: {
+        ouverte: "مفتوحة",
+        close: "مغلقة"
+      }
+    },
+    login: {
+      title: "تسجيل الدخول",
+      emailLabel: "البريد الإلكتروني",
+      passwordLabel: "كلمة المرور",
+      submit: "دخول",
+      socialNote: "دعم تسجيل الدخول الاجتماعي قريبًا."
+    },
+    toastClose: "إغلاق",
+    notFound: {
+      title: "الصفحة غير موجودة",
+      description: "الصفحة المطلوبة غير متوفرة أو تم إزالتها.",
+      back: "العودة إلى الرئيسية"
+    }
+  }
+};

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,786 @@
+:root {
+  color-scheme: dark;
+  --color-background: #0b0f1a;
+  --color-surface: #111827;
+  --color-muted: #9ca3af;
+  --color-border: rgba(255, 255, 255, 0.12);
+  --color-primary: #ffb300;
+  --color-primary-hover: #e6a100;
+  --color-success: #16a34a;
+  --shadow-soft: 0 18px 38px rgba(0, 0, 0, 0.35);
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --max-width: 1100px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, rgba(17, 24, 39, 0.6), transparent 60%), var(--color-background);
+  color: #f9fafb;
+  line-height: 1.6;
+}
+
+html.rtl body {
+  font-family: "Noto Kufi Arabic", "Inter", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+#app {
+  min-height: 100vh;
+}
+
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem clamp(1.25rem, 2.5vw, 2.5rem);
+  backdrop-filter: blur(12px);
+  background: rgba(11, 15, 26, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+}
+
+.site-nav {
+  display: none;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s ease;
+}
+
+.nav-list a[aria-current="page"] {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-primary);
+}
+
+.locale-switch {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.locale-button {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: inherit;
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.locale-button[aria-pressed="true"] {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #111827;
+}
+
+.main {
+  flex: 1;
+  width: min(var(--max-width), 100%);
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 4rem) clamp(1.25rem, 3vw, 3rem) 5rem;
+}
+
+.site-footer {
+  width: min(var(--max-width), 100%);
+  margin: 0 auto;
+  padding: 2.5rem clamp(1.25rem, 3vw, 3rem) 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 2rem;
+  font-size: 0.95rem;
+}
+
+.footer-note {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.page.simple h1,
+.page.form h1,
+.page.home h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0;
+}
+
+.hero {
+  display: grid;
+  gap: 1.5rem;
+  background: linear-gradient(145deg, rgba(255, 179, 0, 0.1), rgba(17, 24, 39, 0.6));
+  border-radius: var(--radius-lg);
+  padding: clamp(1.75rem, 3.5vw, 2.75rem);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-text p {
+  color: rgba(255, 255, 255, 0.88);
+  margin: 0;
+}
+
+.hero-legal {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.25rem;
+}
+
+.hero-legal-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.card-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.category-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.category-icon {
+  font-size: 1.5rem;
+}
+
+.cagnotte-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.cagnotte-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.cagnotte-description {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.6rem;
+  background: rgba(255, 179, 0, 0.12);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.progress {
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-primary), var(--color-primary-hover));
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.stats dt {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+}
+
+.stats dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+  text-align: center;
+}
+
+.button.primary {
+  background: var(--color-primary);
+  color: #0b0f1a;
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  background: var(--color-primary-hover);
+}
+
+.button.secondary {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+  border-color: var(--color-primary);
+}
+
+.button.ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.button.ghost:hover,
+.button.ghost:focus {
+  border-color: var(--color-primary);
+}
+
+.button.full {
+  width: 100%;
+}
+
+.button:active {
+  transform: translateY(1px);
+}
+
+.muted {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.input-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.input,
+.textarea,
+.select {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(15, 23, 42, 0.5);
+  padding: 0.65rem 0.75rem;
+  color: inherit;
+  resize: vertical;
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  outline: 2px solid rgba(255, 179, 0, 0.6);
+  border-color: rgba(255, 179, 0, 0.8);
+}
+
+.textarea {
+  min-height: 140px;
+}
+
+.form-note {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.page.form {
+  gap: 2rem;
+  max-width: 520px;
+}
+
+.page.simple {
+  max-width: 720px;
+}
+
+.steps-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.steps-list li {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.steps-list strong {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.stepper-header {
+  display: flex;
+  overflow-x: auto;
+  gap: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+.stepper-item {
+  min-width: 220px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.stepper-item.active {
+  border-color: var(--color-primary);
+  background: rgba(255, 179, 0, 0.12);
+}
+
+.stepper-item.done {
+  border-color: rgba(22, 163, 74, 0.6);
+}
+
+.stepper-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+}
+
+.stepper-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.stepper-description {
+  margin: 0.25rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.stepper-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stepper-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.step-info {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.step-note {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.dropzone {
+  border: 2px dashed rgba(255, 255, 255, 0.18);
+  border-radius: var(--radius-md);
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.step-radio {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.step-radio input {
+  margin-top: 0.35rem;
+}
+
+.step-radio-title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+
+.step-radio-description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.cagnotte-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.cagnotte-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cagnotte-text {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.cagnotte-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cagnotte-widget h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.widget-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+
+.widget-stats span {
+  display: block;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.widget-stats strong {
+  font-size: 1.2rem;
+}
+
+.contribution-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.contribution {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 0.75rem;
+}
+
+.contribution:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.contribution-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.details div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.details dt {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.toast-container {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 20;
+}
+
+html.rtl .toast-container {
+  right: auto;
+  left: 1.5rem;
+}
+
+.toast {
+  min-width: 260px;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.95);
+  color: #0b0f1a;
+  border-radius: var(--radius-md);
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.25);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.toast.success {
+  border-left: 4px solid var(--color-success);
+}
+
+.toast.warning {
+  border-left: 4px solid var(--color-primary);
+}
+
+.toast.danger {
+  border-left: 4px solid #dc2626;
+}
+
+.toast-header {
+  font-weight: 600;
+}
+
+.toast-body {
+  margin: 0;
+}
+
+.toast-close {
+  justify-self: end;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .site-nav {
+    display: block;
+  }
+
+  .hero {
+    grid-template-columns: 1fr 0.9fr;
+    align-items: center;
+  }
+
+  .cagnotte-layout {
+    grid-template-columns: 2fr 1fr;
+    align-items: flex-start;
+  }
+
+  .stepper-header {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .locale-switch {
+    margin-left: auto;
+  }
+}
+
+html.rtl .site-header {
+  flex-direction: row-reverse;
+}
+
+html.rtl .site-nav .nav-list {
+  flex-direction: row-reverse;
+}
+
+html.rtl .locale-switch {
+  flex-direction: row-reverse;
+  margin-right: auto;
+  margin-left: 0;
+}
+
+html.rtl .section-header,
+html.rtl .category-card,
+html.rtl .cagnotte-card-header,
+html.rtl .contribution-header {
+  flex-direction: row-reverse;
+  text-align: right;
+}
+
+html.rtl .card,
+html.rtl .page,
+html.rtl .site-footer {
+  text-align: right;
+}
+
+html.rtl .stepper-header {
+  flex-direction: row-reverse;
+}
+
+html.rtl .stepper-item,
+html.rtl .stepper-description,
+html.rtl .step-info,
+html.rtl .step-note {
+  text-align: right;
+}
+
+html.rtl .stepper-actions {
+  justify-content: flex-start;
+}
+
+html.rtl .widget-stats,
+html.rtl .stats,
+html.rtl .details {
+  direction: rtl;
+}

--- a/src/ui/createStepper.ts
+++ b/src/ui/createStepper.ts
@@ -1,0 +1,359 @@
+import { categories } from "@data/categories";
+import type { Locale } from "@lib/i18n";
+import type { LocaleMessages } from "@lib/i18n";
+import { showToast } from "./toast";
+
+export type StepKey = "description" | "illustration" | "visibility" | "amounts" | "invitations";
+
+export type FormState = {
+  titre: string;
+  description: string;
+  categorie: string;
+  image: string;
+  visibilite: string;
+  objectifMAD: number;
+  minimumDonation: number;
+  message: string;
+};
+
+const STORAGE_KEY = "tonti-create-cagnotte";
+
+const DEFAULT_STATE: FormState = {
+  titre: "",
+  description: "",
+  categorie: "aid",
+  image: "",
+  visibilite: "publique",
+  objectifMAD: 1000,
+  minimumDonation: 50,
+  message: ""
+};
+
+function loadState(defaultMessage: string): FormState {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { ...DEFAULT_STATE, message: defaultMessage };
+    }
+    const parsed = JSON.parse(raw) as Partial<FormState>;
+    return { ...DEFAULT_STATE, message: defaultMessage, ...parsed };
+  } catch {
+    return { ...DEFAULT_STATE, message: defaultMessage };
+  }
+}
+
+function persist(state: FormState) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function validateStep(step: StepKey, state: FormState, messages: LocaleMessages): string | null {
+  switch (step) {
+    case "description": {
+      if (state.titre.trim().length < 6) return messages.create.toasts.errorDescription;
+      if (state.description.trim().length < 20) return messages.create.toasts.errorDescription;
+      return null;
+    }
+    case "amounts": {
+      if (state.objectifMAD < 1000) return messages.create.toasts.errorDescription;
+      if (state.minimumDonation < 10) return messages.create.toasts.errorDescription;
+      return null;
+    }
+    case "invitations": {
+      if (state.message.trim().length < 10) return messages.create.toasts.errorDescription;
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function createRadio(option: { id: string; label: string; description: string }, value: string, onChange: (next: string) => void) {
+  const wrapper = document.createElement("label");
+  wrapper.className = "step-radio";
+
+  const input = document.createElement("input");
+  input.type = "radio";
+  input.name = "visibilite";
+  input.value = option.id;
+  input.checked = option.id === value;
+  input.addEventListener("change", () => onChange(option.id));
+  wrapper.appendChild(input);
+
+  const content = document.createElement("div");
+  const title = document.createElement("p");
+  title.className = "step-radio-title";
+  title.textContent = option.label;
+  content.appendChild(title);
+
+  const description = document.createElement("p");
+  description.className = "step-radio-description";
+  description.textContent = option.description;
+  content.appendChild(description);
+
+  wrapper.appendChild(content);
+  return wrapper;
+}
+
+export function renderCreateStepper(messages: LocaleMessages, locale: Locale): HTMLElement {
+  const container = document.createElement("div");
+  container.className = "stepper";
+
+  let state = loadState(messages.create.invitationsStep.messagePlaceholder);
+  let currentStep: StepKey = "description";
+
+  const stepOrder: StepKey[] = ["description", "illustration", "visibility", "amounts", "invitations"];
+
+  const header = document.createElement("ol");
+  header.className = "stepper-header";
+  container.appendChild(header);
+
+  const content = document.createElement("div");
+  content.className = "stepper-content";
+  container.appendChild(content);
+
+  const actions = document.createElement("div");
+  actions.className = "stepper-actions";
+  container.appendChild(actions);
+
+  function updateHeader() {
+    header.innerHTML = "";
+    stepOrder.forEach((step, index) => {
+      const item = document.createElement("li");
+      item.className = "stepper-item";
+      if (step === currentStep) item.classList.add("active");
+      if (stepOrder.indexOf(currentStep) > index) item.classList.add("done");
+
+      const number = document.createElement("span");
+      number.className = "stepper-number";
+      number.textContent = String(index + 1);
+      item.appendChild(number);
+
+      const text = document.createElement("div");
+      const title = document.createElement("p");
+      title.className = "stepper-label";
+      title.textContent = messages.create.steps[index].label;
+      text.appendChild(title);
+      const description = document.createElement("p");
+      description.className = "stepper-description";
+      description.textContent = messages.create.steps[index].description;
+      text.appendChild(description);
+
+      item.appendChild(text);
+      header.appendChild(item);
+    });
+  }
+
+  function renderDescriptionStep() {
+    content.innerHTML = "";
+
+    const titleInput = document.createElement("input");
+    titleInput.type = "text";
+    titleInput.className = "input";
+    titleInput.value = state.titre;
+    titleInput.placeholder = messages.create.descriptionStep.titlePlaceholder;
+    titleInput.addEventListener("input", (event) => {
+      state.titre = (event.target as HTMLInputElement).value;
+      persist(state);
+    });
+
+    const titleLabel = document.createElement("label");
+    titleLabel.className = "input-field";
+    titleLabel.textContent = messages.create.descriptionStep.titleLabel;
+    titleLabel.appendChild(titleInput);
+    content.appendChild(titleLabel);
+
+    const descriptionLabel = document.createElement("label");
+    descriptionLabel.className = "input-field";
+    descriptionLabel.textContent = messages.create.descriptionStep.descriptionLabel;
+
+    const descriptionArea = document.createElement("textarea");
+    descriptionArea.className = "textarea";
+    descriptionArea.value = state.description;
+    descriptionArea.placeholder = messages.create.descriptionStep.descriptionPlaceholder;
+    descriptionArea.addEventListener("input", (event) => {
+      state.description = (event.target as HTMLTextAreaElement).value;
+      persist(state);
+    });
+    descriptionLabel.appendChild(descriptionArea);
+    content.appendChild(descriptionLabel);
+
+    const selectLabel = document.createElement("label");
+    selectLabel.className = "input-field";
+    selectLabel.textContent = messages.create.descriptionStep.categoryLabel;
+
+    const select = document.createElement("select");
+    select.className = "select";
+    categories.forEach((category) => {
+      const option = document.createElement("option");
+      option.value = category.id;
+      option.textContent = category.label[locale];
+      if (state.categorie === category.id) option.selected = true;
+      select.appendChild(option);
+    });
+    select.addEventListener("change", (event) => {
+      state.categorie = (event.target as HTMLSelectElement).value;
+      persist(state);
+    });
+    selectLabel.appendChild(select);
+    content.appendChild(selectLabel);
+  }
+
+  function renderIllustrationStep() {
+    content.innerHTML = "";
+    const info = document.createElement("p");
+    info.className = "step-info";
+    info.textContent = messages.create.illustrationStep.intro;
+    content.appendChild(info);
+
+    const placeholder = document.createElement("div");
+    placeholder.className = "dropzone";
+    placeholder.textContent = messages.create.illustrationStep.placeholder;
+    content.appendChild(placeholder);
+  }
+
+  function renderVisibilityStep() {
+    content.innerHTML = "";
+    const info = document.createElement("p");
+    info.className = "step-info";
+    info.textContent = messages.create.visibilityStep.intro;
+    content.appendChild(info);
+
+    messages.create.visibilityStep.options.forEach((option) => {
+      const radio = createRadio(option, state.visibilite, (next) => {
+        state.visibilite = next;
+        persist(state);
+        renderVisibilityStep();
+      });
+      content.appendChild(radio);
+    });
+  }
+
+  function renderAmountsStep() {
+    content.innerHTML = "";
+
+    const goalLabel = document.createElement("label");
+    goalLabel.className = "input-field";
+    goalLabel.textContent = messages.create.amountsStep.goalLabel;
+
+    const goalInput = document.createElement("input");
+    goalInput.type = "number";
+    goalInput.className = "input";
+    goalInput.value = String(state.objectifMAD);
+    goalInput.min = "0";
+    goalInput.addEventListener("input", (event) => {
+      state.objectifMAD = Number((event.target as HTMLInputElement).value);
+      persist(state);
+    });
+    goalLabel.appendChild(goalInput);
+    content.appendChild(goalLabel);
+
+    const minLabel = document.createElement("label");
+    minLabel.className = "input-field";
+    minLabel.textContent = messages.create.amountsStep.minLabel;
+
+    const minInput = document.createElement("input");
+    minInput.type = "number";
+    minInput.className = "input";
+    minInput.value = String(state.minimumDonation);
+    minInput.min = "0";
+    minInput.addEventListener("input", (event) => {
+      state.minimumDonation = Number((event.target as HTMLInputElement).value);
+      persist(state);
+    });
+    minLabel.appendChild(minInput);
+    content.appendChild(minLabel);
+
+    const note = document.createElement("p");
+    note.className = "step-note";
+    note.textContent = messages.create.amountsStep.feesNotice;
+    content.appendChild(note);
+  }
+
+  function renderInvitationsStep() {
+    content.innerHTML = "";
+
+    const info = document.createElement("p");
+    info.className = "step-info";
+    info.textContent = messages.create.invitationsStep.intro;
+    content.appendChild(info);
+
+    const messageArea = document.createElement("textarea");
+    messageArea.className = "textarea";
+    messageArea.value = state.message;
+    messageArea.placeholder = messages.create.invitationsStep.messagePlaceholder;
+    messageArea.addEventListener("input", (event) => {
+      state.message = (event.target as HTMLTextAreaElement).value;
+      persist(state);
+    });
+    content.appendChild(messageArea);
+
+    const note = document.createElement("p");
+    note.className = "step-note";
+    note.textContent = messages.create.invitationsStep.note;
+    content.appendChild(note);
+  }
+
+  function renderContent() {
+    switch (currentStep) {
+      case "description":
+        renderDescriptionStep();
+        break;
+      case "illustration":
+        renderIllustrationStep();
+        break;
+      case "visibility":
+        renderVisibilityStep();
+        break;
+      case "amounts":
+        renderAmountsStep();
+        break;
+      case "invitations":
+        renderInvitationsStep();
+        break;
+    }
+  }
+
+  function goToNext() {
+    const error = validateStep(currentStep, state, messages);
+    if (error) {
+      showToast({ id: crypto.randomUUID(), title: messages.create.toasts.errorTitle, description: error, tone: "warning" });
+      return;
+    }
+    const index = stepOrder.indexOf(currentStep);
+    if (index === stepOrder.length - 1) {
+      showToast({ id: crypto.randomUUID(), title: messages.create.toasts.successTitle, description: messages.create.toasts.successDescription, tone: "success" });
+      return;
+    }
+    currentStep = stepOrder[index + 1];
+    updateHeader();
+    renderContent();
+  }
+
+  function skipStep() {
+    const index = stepOrder.indexOf(currentStep);
+    if (index < stepOrder.length - 1) {
+      currentStep = stepOrder[index + 1];
+      updateHeader();
+      renderContent();
+    }
+  }
+
+  const skipButton = document.createElement("button");
+  skipButton.type = "button";
+  skipButton.className = "button ghost";
+  skipButton.textContent = messages.create.actions.skip;
+  skipButton.addEventListener("click", skipStep);
+  actions.appendChild(skipButton);
+
+  const nextButton = document.createElement("button");
+  nextButton.type = "button";
+  nextButton.className = "button primary";
+  nextButton.textContent = messages.create.actions.continue;
+  nextButton.addEventListener("click", goToNext);
+  actions.appendChild(nextButton);
+
+  updateHeader();
+  renderContent();
+
+  return container;
+}

--- a/src/ui/dom.ts
+++ b/src/ui/dom.ts
@@ -1,0 +1,21 @@
+export type ElementOptions = {
+  classes?: string[];
+  text?: string;
+};
+
+export function el<K extends keyof HTMLElementTagNameMap>(tag: K, options: ElementOptions = {}): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag);
+  if (options.classes) {
+    element.className = options.classes.join(" ");
+  }
+  if (options.text) {
+    element.textContent = options.text;
+  }
+  return element;
+}
+
+export function clearChildren(node: HTMLElement) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,0 +1,73 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+export type ToastTone = "success" | "warning" | "danger";
+
+export type ToastMessage = {
+  id: string;
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+};
+
+const toasts: ToastMessage[] = [];
+let container: HTMLElement | null = null;
+let closeLabel = "Fermer";
+
+function ensureContainer(): HTMLElement {
+  if (!container) {
+    container = document.createElement("div");
+    container.className = "toast-container";
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+function render() {
+  const target = ensureContainer();
+  target.innerHTML = "";
+  for (const toast of toasts) {
+    const item = document.createElement("div");
+    item.className = `toast ${toast.tone ?? ""}`.trim();
+
+    const header = document.createElement("div");
+    header.className = "toast-header";
+    header.textContent = toast.title;
+    item.appendChild(header);
+
+    if (toast.description) {
+      const body = document.createElement("p");
+      body.className = "toast-body";
+      body.textContent = toast.description;
+      item.appendChild(body);
+    }
+
+    const button = document.createElement("button");
+    button.className = "toast-close";
+    button.textContent = closeLabel;
+    button.addEventListener("click", () => dismiss(toast.id));
+    item.appendChild(button);
+
+    target.appendChild(item);
+  }
+}
+
+export function showToast(message: ToastMessage, lifetime = 4000) {
+  toasts.push(message);
+  render();
+  if (lifetime > 0) {
+    window.setTimeout(() => dismiss(message.id), lifetime);
+  }
+}
+
+export function dismiss(id: string) {
+  const index = toasts.findIndex((toast) => toast.id === id);
+  if (index >= 0) {
+    toasts.splice(index, 1);
+    render();
+  }
+}
+
+export function configureToasts(messages: LocaleMessages) {
+  closeLabel = messages.toastClose;
+  render();
+}

--- a/src/views/cagnotte.ts
+++ b/src/views/cagnotte.ts
@@ -1,0 +1,211 @@
+import { cagnottes } from "@data/cagnottes";
+import { formatMAD } from "@lib/currency";
+import { daysRemaining, formatRelative } from "@lib/date";
+import type { Locale } from "@lib/i18n";
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderCagnotte(messages: LocaleMessages, locale: Locale, slug: string): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page cagnotte";
+
+  const cagnotte = cagnottes.find((item) => item.id === slug);
+  if (!cagnotte) {
+    const title = document.createElement("h1");
+    title.textContent = messages.cagnotte.notFoundTitle;
+    section.appendChild(title);
+    const paragraph = document.createElement("p");
+    paragraph.textContent = messages.cagnotte.notFoundDescription;
+    section.appendChild(paragraph);
+    const link = document.createElement("a");
+    const url = locale === "fr" ? "/" : "/ar";
+    link.href = url;
+    link.setAttribute("data-route", url);
+    link.className = "button primary";
+    link.textContent = messages.cagnotte.backHome;
+    section.appendChild(link);
+    return section;
+  }
+
+  const layout = document.createElement("div");
+  layout.className = "cagnotte-layout";
+
+  const main = document.createElement("article");
+  main.className = "cagnotte-main";
+
+  const header = document.createElement("div");
+  header.className = "cagnotte-header";
+  const title = document.createElement("h1");
+  title.textContent = cagnotte.titre;
+  header.appendChild(title);
+  const organiser = document.createElement("p");
+  organiser.className = "muted";
+  organiser.textContent = `${messages.cagnotte.organizerPrefix} ${cagnotte.organisateur.nom}`;
+  header.appendChild(organiser);
+  main.appendChild(header);
+
+  const description = document.createElement("p");
+  description.className = "cagnotte-text";
+  description.textContent = cagnotte.description;
+  main.appendChild(description);
+
+  const widget = document.createElement("div");
+  widget.className = "cagnotte-widget";
+  const widgetTitle = document.createElement("h2");
+  widgetTitle.textContent = messages.cagnotte.progressTitle;
+  widget.appendChild(widgetTitle);
+  const progress = document.createElement("div");
+  progress.className = "progress";
+  const progressBar = document.createElement("div");
+  progressBar.className = "progress-bar";
+  const percentage = Math.min(Math.round((cagnotte.collecteMAD / cagnotte.objectifMAD) * 100), 100);
+  progressBar.style.width = `${percentage}%`;
+  progress.appendChild(progressBar);
+  widget.appendChild(progress);
+
+  const stats = document.createElement("div");
+  stats.className = "widget-stats";
+
+  const collected = document.createElement("div");
+  const collectedLabel = document.createElement("span");
+  collectedLabel.textContent = messages.cagnotte.collectedLabel;
+  const collectedValue = document.createElement("strong");
+  collectedValue.textContent = formatMAD(cagnotte.collecteMAD);
+  collected.appendChild(collectedLabel);
+  collected.appendChild(collectedValue);
+  stats.appendChild(collected);
+
+  const goal = document.createElement("div");
+  const goalLabel = document.createElement("span");
+  goalLabel.textContent = messages.cagnotte.goalLabel;
+  const goalValue = document.createElement("strong");
+  goalValue.textContent = formatMAD(cagnotte.objectifMAD);
+  goal.appendChild(goalLabel);
+  goal.appendChild(goalValue);
+  stats.appendChild(goal);
+
+  const remaining = document.createElement("div");
+  const remainingLabel = document.createElement("span");
+  remainingLabel.textContent = messages.cagnotte.daysLeftLabel;
+  const remainingValue = document.createElement("strong");
+  remainingValue.textContent = String(daysRemaining(cagnotte.dateFin));
+  remaining.appendChild(remainingLabel);
+  remaining.appendChild(remainingValue);
+  stats.appendChild(remaining);
+  widget.appendChild(stats);
+
+  const participate = document.createElement("button");
+  participate.className = "button primary full";
+  participate.textContent = messages.cagnotte.participateCta;
+  widget.appendChild(participate);
+
+  main.appendChild(widget);
+
+  const participants = document.createElement("section");
+  participants.className = "card";
+  const participantsHeader = document.createElement("header");
+  participantsHeader.className = "card-header";
+  const participantsTitle = document.createElement("h2");
+  participantsTitle.textContent = messages.cagnotte.recentParticipants;
+  participantsHeader.appendChild(participantsTitle);
+  const count = document.createElement("span");
+  count.className = "muted";
+  count.textContent = messages.cagnotte.participantsCount.replace("{count}", String(cagnotte.participants));
+  participantsHeader.appendChild(count);
+  participants.appendChild(participantsHeader);
+
+  const list = document.createElement("div");
+  list.className = "contribution-list";
+  cagnotte.historique.forEach((contribution) => {
+    const item = document.createElement("article");
+    item.className = "contribution";
+    const headerRow = document.createElement("div");
+    headerRow.className = "contribution-header";
+    const name = document.createElement("span");
+    name.textContent = contribution.nom;
+    headerRow.appendChild(name);
+    const amount = document.createElement("strong");
+    amount.textContent = formatMAD(contribution.montantMAD);
+    headerRow.appendChild(amount);
+    item.appendChild(headerRow);
+    const time = document.createElement("p");
+    time.className = "muted";
+    time.textContent = formatRelative(contribution.date, locale);
+    item.appendChild(time);
+    list.appendChild(item);
+  });
+  participants.appendChild(list);
+  main.appendChild(participants);
+
+  layout.appendChild(main);
+
+  const aside = document.createElement("aside");
+  aside.className = "cagnotte-aside";
+
+  const details = document.createElement("div");
+  details.className = "card";
+  const detailsTitle = document.createElement("h2");
+  detailsTitle.textContent = messages.cagnotte.detailsTitle;
+  details.appendChild(detailsTitle);
+
+  const dl = document.createElement("dl");
+  dl.className = "details";
+
+  const beneficiary = document.createElement("div");
+  const beneficiaryLabel = document.createElement("dt");
+  beneficiaryLabel.textContent = messages.cagnotte.beneficiaryLabel;
+  const beneficiaryValue = document.createElement("dd");
+  beneficiaryValue.textContent = cagnotte.beneficiaire.nom;
+  beneficiary.appendChild(beneficiaryLabel);
+  beneficiary.appendChild(beneficiaryValue);
+  dl.appendChild(beneficiary);
+
+  const visibility = document.createElement("div");
+  const visibilityLabel = document.createElement("dt");
+  visibilityLabel.textContent = messages.cagnotte.visibilityLabel;
+  const visibilityValue = document.createElement("dd");
+  const visibilityText = messages.cagnotte.visibilityMap[cagnotte.visibilite] ?? cagnotte.visibilite;
+  visibilityValue.textContent = visibilityText;
+  visibility.appendChild(visibilityLabel);
+  visibility.appendChild(visibilityValue);
+  dl.appendChild(visibility);
+
+  const status = document.createElement("div");
+  const statusLabel = document.createElement("dt");
+  statusLabel.textContent = messages.cagnotte.statusLabel;
+  const statusValue = document.createElement("dd");
+  const statusText = messages.cagnotte.statusMap[cagnotte.statut] ?? cagnotte.statut;
+  statusValue.textContent = statusText;
+  status.appendChild(statusLabel);
+  status.appendChild(statusValue);
+  dl.appendChild(status);
+  details.appendChild(dl);
+
+  const note = document.createElement("p");
+  note.className = "muted";
+  note.textContent = messages.cagnotte.paymentNote;
+  details.appendChild(note);
+  aside.appendChild(details);
+
+  const loginCard = document.createElement("div");
+  loginCard.className = "card";
+  const loginTitle = document.createElement("h3");
+  loginTitle.textContent = messages.cagnotte.loginTitle;
+  loginCard.appendChild(loginTitle);
+  const loginDescription = document.createElement("p");
+  loginDescription.className = "muted";
+  loginDescription.textContent = messages.cagnotte.loginDescription;
+  loginCard.appendChild(loginDescription);
+  const loginLink = document.createElement("a");
+  const loginUrl = locale === "fr" ? "/auth/login" : "/ar/auth/login";
+  loginLink.href = loginUrl;
+  loginLink.setAttribute("data-route", loginUrl);
+  loginLink.className = "button secondary full";
+  loginLink.textContent = messages.cagnotte.loginCta;
+  loginCard.appendChild(loginLink);
+  aside.appendChild(loginCard);
+
+  layout.appendChild(aside);
+  section.appendChild(layout);
+
+  return section;
+}

--- a/src/views/create.ts
+++ b/src/views/create.ts
@@ -1,0 +1,22 @@
+import type { Locale } from "@lib/i18n";
+import type { LocaleMessages } from "@lib/i18n";
+import { renderCreateStepper } from "@ui/createStepper";
+
+export function renderCreate(messages: LocaleMessages, locale: Locale): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.create.title;
+  section.appendChild(title);
+
+  const description = document.createElement("p");
+  description.className = "muted";
+  description.textContent = messages.create.description;
+  section.appendChild(description);
+
+  const stepper = renderCreateStepper(messages, locale);
+  section.appendChild(stepper);
+
+  return section;
+}

--- a/src/views/faq.ts
+++ b/src/views/faq.ts
@@ -1,0 +1,24 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderFaq(messages: LocaleMessages): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.faq.title;
+  section.appendChild(title);
+
+  messages.faq.items.forEach((item) => {
+    const details = document.createElement("details");
+    if (item.defaultOpen) details.open = true;
+    const summary = document.createElement("summary");
+    summary.textContent = item.question;
+    details.appendChild(summary);
+    const paragraph = document.createElement("p");
+    paragraph.textContent = item.answer;
+    details.appendChild(paragraph);
+    section.appendChild(details);
+  });
+
+  return section;
+}

--- a/src/views/help.ts
+++ b/src/views/help.ts
@@ -1,0 +1,16 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderHelp(messages: LocaleMessages): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.help.title;
+  section.appendChild(title);
+
+  const paragraph = document.createElement("p");
+  paragraph.textContent = messages.help.description;
+  section.appendChild(paragraph);
+
+  return section;
+}

--- a/src/views/home.ts
+++ b/src/views/home.ts
@@ -1,0 +1,163 @@
+import { categories } from "@data/categories";
+import { cagnottes } from "@data/cagnottes";
+import { formatMAD } from "@lib/currency";
+import { daysRemaining } from "@lib/date";
+import type { Locale } from "@lib/i18n";
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderHome(messages: LocaleMessages, locale: Locale): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page home";
+
+  const hero = document.createElement("div");
+  hero.className = "hero";
+  const heroText = document.createElement("div");
+  heroText.className = "hero-text";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.home.heroTitle;
+  heroText.appendChild(title);
+
+  const subtitle = document.createElement("p");
+  subtitle.textContent = messages.home.heroSubtitle;
+  heroText.appendChild(subtitle);
+
+  const cta = document.createElement("a");
+  cta.textContent = messages.home.heroCta;
+  cta.href = locale === "fr" ? "/cagnotte/creer" : "/ar/cagnotte/creer";
+  cta.setAttribute("data-route", cta.href);
+  cta.className = "button primary";
+  heroText.appendChild(cta);
+
+  hero.appendChild(heroText);
+
+  const legal = document.createElement("div");
+  legal.className = "hero-legal";
+  const legalTitle = document.createElement("p");
+  legalTitle.className = "hero-legal-title";
+  legalTitle.textContent = messages.home.legalHeading;
+  legal.appendChild(legalTitle);
+  const legalText = document.createElement("p");
+  legalText.textContent = messages.home.legalDescription;
+  legal.appendChild(legalText);
+  hero.appendChild(legal);
+
+  section.appendChild(hero);
+
+  const categoriesSection = document.createElement("div");
+  categoriesSection.className = "card-section";
+  const categoriesTitle = document.createElement("h2");
+  categoriesTitle.textContent = messages.home.categoriesTitle;
+  categoriesSection.appendChild(categoriesTitle);
+
+  const categoriesGrid = document.createElement("div");
+  categoriesGrid.className = "grid three";
+  categories.forEach((category) => {
+    const card = document.createElement("div");
+    card.className = "category-card";
+    const icon = document.createElement("span");
+    icon.className = "category-icon";
+    icon.textContent = category.icon;
+    card.appendChild(icon);
+    const label = document.createElement("span");
+    label.textContent = category.label[locale];
+    card.appendChild(label);
+    categoriesGrid.appendChild(card);
+  });
+  categoriesSection.appendChild(categoriesGrid);
+  section.appendChild(categoriesSection);
+
+  const featuredSection = document.createElement("div");
+  featuredSection.className = "card-section";
+  const featuredHeader = document.createElement("div");
+  featuredHeader.className = "section-header";
+  const featuredTitle = document.createElement("h2");
+  featuredTitle.textContent = messages.home.featuredTitle;
+  featuredHeader.appendChild(featuredTitle);
+  const featuredLink = document.createElement("a");
+  featuredLink.href = locale === "fr" ? "/cagnotte/creer" : "/ar/cagnotte/creer";
+  featuredLink.setAttribute("data-route", featuredLink.href);
+  featuredLink.textContent = messages.home.featuredCta;
+  featuredHeader.appendChild(featuredLink);
+  featuredSection.appendChild(featuredHeader);
+
+  const featuredGrid = document.createElement("div");
+  featuredGrid.className = "grid two";
+
+  cagnottes.forEach((cagnotte) => {
+    const article = document.createElement("article");
+    article.className = "cagnotte-card";
+
+    const header = document.createElement("div");
+    header.className = "cagnotte-card-header";
+    const h3 = document.createElement("h3");
+    h3.textContent = cagnotte.titre;
+    header.appendChild(h3);
+    const badge = document.createElement("span");
+    badge.className = "badge";
+    badge.textContent = cagnotte.categorie;
+    header.appendChild(badge);
+    article.appendChild(header);
+
+    const description = document.createElement("p");
+    description.className = "cagnotte-description";
+    description.textContent = cagnotte.description;
+    article.appendChild(description);
+
+    const progress = document.createElement("div");
+    progress.className = "progress";
+    const progressBar = document.createElement("div");
+    progressBar.className = "progress-bar";
+    const percentage = Math.min(Math.round((cagnotte.collecteMAD / cagnotte.objectifMAD) * 100), 100);
+    progressBar.style.width = `${percentage}%`;
+    progress.appendChild(progressBar);
+    article.appendChild(progress);
+
+    const stats = document.createElement("dl");
+    stats.className = "stats";
+
+    const collected = document.createElement("div");
+    const collectedLabel = document.createElement("dt");
+    collectedLabel.textContent = messages.home.cardCollected;
+    const collectedValue = document.createElement("dd");
+    collectedValue.textContent = formatMAD(cagnotte.collecteMAD);
+    collected.appendChild(collectedLabel);
+    collected.appendChild(collectedValue);
+    stats.appendChild(collected);
+
+    const goal = document.createElement("div");
+    const goalLabel = document.createElement("dt");
+    goalLabel.textContent = messages.home.cardGoal;
+    const goalValue = document.createElement("dd");
+    goalValue.textContent = formatMAD(cagnotte.objectifMAD);
+    goal.appendChild(goalLabel);
+    goal.appendChild(goalValue);
+    stats.appendChild(goal);
+
+    const remaining = document.createElement("div");
+    const remainingLabel = document.createElement("dt");
+    remainingLabel.textContent = messages.home.cardDaysLeft;
+    const remainingValue = document.createElement("dd");
+    remainingValue.textContent = String(daysRemaining(cagnotte.dateFin));
+    remaining.appendChild(remainingLabel);
+    remaining.appendChild(remainingValue);
+    stats.appendChild(remaining);
+
+    article.appendChild(stats);
+
+    const link = document.createElement("a");
+    link.className = "button secondary";
+    const url = locale === "fr" ? `/cagnotte/${cagnotte.id}` : `/ar/cagnotte/${cagnotte.id}`;
+    link.href = url;
+    link.setAttribute("data-route", url);
+    link.textContent = messages.home.cardView;
+    article.appendChild(link);
+
+    featuredGrid.appendChild(article);
+  });
+
+  featuredSection.appendChild(featuredGrid);
+  section.appendChild(featuredSection);
+
+  return section;
+}

--- a/src/views/how.ts
+++ b/src/views/how.ts
@@ -1,0 +1,26 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderHow(messages: LocaleMessages): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.how.title;
+  section.appendChild(title);
+
+  const list = document.createElement("ol");
+  list.className = "steps-list";
+  messages.how.steps.forEach((step) => {
+    const item = document.createElement("li");
+    const strong = document.createElement("strong");
+    strong.textContent = step.title;
+    item.appendChild(strong);
+    const description = document.createElement("p");
+    description.textContent = step.description;
+    item.appendChild(description);
+    list.appendChild(item);
+  });
+  section.appendChild(list);
+
+  return section;
+}

--- a/src/views/legalPage.ts
+++ b/src/views/legalPage.ts
@@ -1,0 +1,19 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+type Key = "legal" | "privacy" | "terms";
+
+export function renderLegalPage(messages: LocaleMessages, key: Key): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const data = messages[key];
+  const title = document.createElement("h1");
+  title.textContent = data.title;
+  section.appendChild(title);
+
+  const paragraph = document.createElement("p");
+  paragraph.textContent = data.description;
+  section.appendChild(paragraph);
+
+  return section;
+}

--- a/src/views/login.ts
+++ b/src/views/login.ts
@@ -1,0 +1,50 @@
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderLogin(messages: LocaleMessages): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page form";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.login.title;
+  section.appendChild(title);
+
+  const form = document.createElement("form");
+  form.className = "card";
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+  });
+
+  const emailLabel = document.createElement("label");
+  emailLabel.className = "input-field";
+  emailLabel.textContent = messages.login.emailLabel;
+  const emailInput = document.createElement("input");
+  emailInput.type = "email";
+  emailInput.required = true;
+  emailInput.className = "input";
+  emailLabel.appendChild(emailInput);
+  form.appendChild(emailLabel);
+
+  const passwordLabel = document.createElement("label");
+  passwordLabel.className = "input-field";
+  passwordLabel.textContent = messages.login.passwordLabel;
+  const passwordInput = document.createElement("input");
+  passwordInput.type = "password";
+  passwordInput.required = true;
+  passwordInput.className = "input";
+  passwordLabel.appendChild(passwordInput);
+  form.appendChild(passwordLabel);
+
+  const button = document.createElement("button");
+  button.type = "submit";
+  button.className = "button primary full";
+  button.textContent = messages.login.submit;
+  form.appendChild(button);
+
+  const note = document.createElement("p");
+  note.className = "form-note";
+  note.textContent = messages.login.socialNote;
+  form.appendChild(note);
+
+  section.appendChild(form);
+  return section;
+}

--- a/src/views/notFound.ts
+++ b/src/views/notFound.ts
@@ -1,0 +1,26 @@
+import type { Locale } from "@lib/i18n";
+import type { LocaleMessages } from "@lib/i18n";
+
+export function renderNotFound(messages: LocaleMessages, locale: Locale): HTMLElement {
+  const section = document.createElement("section");
+  section.className = "page simple";
+
+  const title = document.createElement("h1");
+  title.textContent = messages.notFound.title;
+  section.appendChild(title);
+
+  const description = document.createElement("p");
+  description.className = "muted";
+  description.textContent = messages.notFound.description;
+  section.appendChild(description);
+
+  const link = document.createElement("a");
+  const href = locale === "fr" ? "/" : "/ar";
+  link.href = href;
+  link.setAttribute("data-route", href);
+  link.className = "button primary";
+  link.textContent = messages.notFound.back;
+  section.appendChild(link);
+
+  return section;
+}

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ["stylelint-config-standard", "stylelint-config-standard-scss"],
+  plugins: ["stylelint-order"],
+  rules: {
+    "order/properties-alphabetical-order": true
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["src/core/*"],
+      "@data/*": ["src/data/*"],
+      "@lib/*": ["src/lib/*"],
+      "@ui/*": ["src/ui/*"],
+      "@views/*": ["src/views/*"]
+    }
+  },
+  "include": ["src", "scripts"]
+}


### PR DESCRIPTION
## Summary
- remove unsupported binary JPEG placeholders from the public assets folder
- add accessible SVG cover illustrations and point mock data to the new vector sources

## Testing
- npm install *(fails: registry returns 403 for esbuild in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e407d662108323993df1f3b4968635