### PR TITLE
Add missing Tailwind CSS plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.12",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "vite": "^5.2.8",


### PR DESCRIPTION
## Summary
- add the Tailwind CSS forms and typography plugins to the devDependencies so the Tailwind config can load them during builds

## Testing
- npm install *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fforms)*

------
https://chatgpt.com/codex/tasks/task_b_68e506b1291c8323b601ad6c30614353