### PR TITLE
feat: refresh UI/UX and enable public GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,20 +10,34 @@ permissions:
   pages: write
   id-token: write
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VITE_BASE_URL: /Tonti/
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+
       - name: Install dependencies
-        run: npm install
-      - name: Build
+        run: npm ci
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build (SSG)
         run: npm run build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
     <meta property="og:description" content="Organisez, suivez et partagez vos Darets en ligne." />
     <meta property="og:url" content="https://naciro2010.github.io/Tonti/" />
     <meta property="og:image" content="https://naciro2010.github.io/Tonti/og.png" />
-    <link rel="icon" type="image/svg+xml" href="/Tonti/favicon.svg" />
+    <meta name="theme-color" content="#0B0F1A" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,13 +1,21 @@
-import { copyFile, constants } from 'node:fs/promises';
+import { copyFile, writeFile, constants } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 const distDir = resolve('dist');
 const indexPath = resolve(distDir, 'index.html');
 const notFoundPath = resolve(distDir, '404.html');
+const noJekyllPath = resolve(distDir, '.nojekyll');
 
 try {
   await copyFile(indexPath, notFoundPath, constants.COPYFILE_FICLONE);
   console.log('Created dist/404.html for SPA fallback.');
 } catch (error) {
   console.warn('Unable to create 404.html fallback:', error);
+}
+
+try {
+  await writeFile(noJekyllPath, '');
+  console.log('Created dist/.nojekyll for GitHub Pages.');
+} catch (error) {
+  console.warn('Unable to create .nojekyll:', error);
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@ const auth = useAuthStore();
 const notifications = useNotifications();
 const { toasts, dismiss } = useToast();
 const showUserMenu = ref(false);
+const mobileMenuOpen = ref(false);
 
 watch(
   storedLocale,
@@ -49,6 +50,11 @@ watch(() => auth.isAuthenticated.value, (authenticated) => {
   }
 });
 
+watch(() => route.path, () => {
+  mobileMenuOpen.value = false;
+  showUserMenu.value = false;
+});
+
 async function handleLogout() {
   showUserMenu.value = false;
   await auth.logout();
@@ -75,84 +81,111 @@ const navigation = computed(() => {
   <div :class="['min-h-screen bg-background text-white', isRtl ? 'font-arabic' : 'font-sans']">
     <a
       href="#main"
-      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-xl focus:bg-primary focus:px-4 focus:py-2 focus:text-background"
+      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-xl focus:bg-primary focus:px-4 focus:py-2 focus:text-background focus:shadow-glow"
     >
       Aller au contenu
     </a>
-    <header class="border-b border-white/10 bg-background/80 backdrop-blur supports-backdrop:bg-background/60">
-      <div class="container-responsive flex flex-wrap items-center justify-between gap-4 py-4">
-        <RouterLink to="/" class="text-xl font-semibold">{{ t('app.name') }}</RouterLink>
-        <nav class="flex flex-wrap items-center gap-3">
+
+    <header
+      class="sticky top-0 z-40 border-b border-white/10 bg-background/80 backdrop-blur-md supports-backdrop:bg-background/60"
+    >
+      <div class="container-responsive flex items-center justify-between gap-3 py-3.5">
+        <RouterLink
+          to="/"
+          class="group inline-flex items-center gap-2 text-xl font-bold tracking-tight no-underline"
+        >
+          <span
+            class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/15 text-primary ring-1 ring-inset ring-primary/25 transition-all group-hover:bg-primary/25"
+          >
+            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M6 6h12v3H6zM8 11h8v3H8zM10 16h4v3h-4z" />
+            </svg>
+          </span>
+          <span class="text-white">{{ t('app.name') }}</span>
+        </RouterLink>
+
+        <nav class="hidden items-center gap-1 md:flex" aria-label="Navigation principale">
           <RouterLink
             v-for="item in navigation"
             :key="item.to"
             :to="item.to"
-            class="rounded-full px-3 py-1 text-sm font-medium text-white/70 transition hover:text-white"
+            class="rounded-full px-3 py-1.5 text-sm font-medium text-white/70 transition-colors hover:text-white no-underline"
             :class="route.path === item.to ? 'bg-white/10 text-white' : ''"
           >
             {{ item.name }}
           </RouterLink>
+        </nav>
 
-          <!-- Language toggle -->
-          <button type="button" class="rounded-full border border-white/20 px-3 py-1 text-sm" @click="toggleLocale">
-            {{ t('app.language') }}: {{ locale }}
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="hidden items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-white/80 transition-colors hover:border-white/20 hover:bg-white/10 sm:inline-flex"
+            @click="toggleLocale"
+            :aria-label="`${t('app.language')}: ${locale}`"
+          >
+            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 5h12M9 3v2m1 9.5A18 18 0 016 9m6 9h7M11 21l5-10 5 10" />
+            </svg>
+            {{ locale }}
           </button>
 
-          <!-- Authenticated user controls -->
           <template v-if="auth.isAuthenticated.value">
-            <!-- Notification bell -->
             <button
               type="button"
-              class="relative rounded-full p-2 text-white/70 transition hover:bg-white/10 hover:text-white"
+              class="relative rounded-full p-2 text-white/70 transition-colors hover:bg-white/10 hover:text-white"
               @click="router.push('/mes-darets')"
               title="Notifications"
+              aria-label="Notifications"
             >
-              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
               </svg>
               <span
                 v-if="notifications.unreadCount.value > 0"
-                class="absolute -right-0.5 -top-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-danger px-1 text-[10px] font-bold"
+                class="absolute -right-0.5 -top-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-danger px-1 text-[10px] font-bold ring-2 ring-background"
               >
                 {{ notifications.unreadCount.value > 99 ? '99+' : notifications.unreadCount.value }}
               </span>
             </button>
 
-            <!-- User avatar menu -->
             <div class="relative">
               <button
                 type="button"
-                class="flex h-8 w-8 items-center justify-center rounded-full bg-primary/20 text-sm font-bold text-primary transition hover:bg-primary/30"
+                class="flex h-9 w-9 items-center justify-center rounded-full bg-primary/20 text-sm font-bold text-primary ring-1 ring-inset ring-primary/30 transition-all hover:bg-primary/30 hover:scale-105"
                 @click="showUserMenu = !showUserMenu"
+                :aria-expanded="showUserMenu"
+                aria-label="Menu utilisateur"
               >
                 {{ auth.initials.value }}
               </button>
 
-              <!-- Dropdown -->
               <Transition
-                enter-active-class="transition duration-100 ease-out"
+                enter-active-class="transition duration-150 ease-out"
                 enter-from-class="scale-95 opacity-0"
                 enter-to-class="scale-100 opacity-100"
-                leave-active-class="transition duration-75 ease-in"
+                leave-active-class="transition duration-100 ease-in"
                 leave-from-class="scale-100 opacity-100"
                 leave-to-class="scale-95 opacity-0"
               >
                 <div
                   v-if="showUserMenu"
-                  class="absolute right-0 z-50 mt-2 w-56 overflow-hidden rounded-xl border border-white/10 bg-surface shadow-xl"
+                  class="absolute right-0 z-50 mt-2 w-60 overflow-hidden rounded-2xl border border-white/10 bg-surface/95 shadow-2xl backdrop-blur-md rtl:left-0 rtl:right-auto"
                   @click="showUserMenu = false"
                 >
                   <div class="border-b border-white/10 px-4 py-3">
-                    <p class="text-sm font-medium">{{ auth.fullName.value }}</p>
-                    <p class="text-xs text-white/50">{{ auth.user.value?.email }}</p>
+                    <p class="text-sm font-semibold text-white">{{ auth.fullName.value }}</p>
+                    <p class="truncate text-xs text-white/50">{{ auth.user.value?.email }}</p>
                   </div>
                   <div class="py-1">
-                    <RouterLink to="/mes-darets" class="block px-4 py-2 text-sm text-white/70 hover:bg-white/5 hover:text-white">
+                    <RouterLink
+                      to="/mes-darets"
+                      class="block px-4 py-2 text-sm text-white/80 no-underline transition-colors hover:bg-white/5 hover:text-white"
+                    >
                       Mes Darets
                     </RouterLink>
                     <button
                       type="button"
-                      class="block w-full px-4 py-2 text-left text-sm text-danger hover:bg-white/5"
+                      class="block w-full px-4 py-2 text-left text-sm font-medium text-dangerSoft transition-colors hover:bg-danger/10"
                       @click="handleLogout"
                     >
                       {{ t('auth.logout') }}
@@ -163,30 +196,94 @@ const navigation = computed(() => {
             </div>
           </template>
 
-          <!-- Login button for unauthenticated users -->
           <template v-else>
             <RouterLink
               to="/login"
-              class="rounded-full bg-primary px-4 py-1.5 text-sm font-medium text-background transition hover:bg-primaryHover"
+              class="hidden rounded-full bg-primary px-4 py-1.5 text-sm font-semibold text-background shadow-glow transition-all hover:bg-primaryHover hover:shadow-glow-lg sm:inline-flex no-underline"
             >
               {{ t('auth.login') }}
             </RouterLink>
           </template>
-        </nav>
+
+          <button
+            type="button"
+            class="inline-flex items-center justify-center rounded-lg p-2 text-white/80 hover:bg-white/10 md:hidden"
+            @click="mobileMenuOpen = !mobileMenuOpen"
+            :aria-expanded="mobileMenuOpen"
+            aria-label="Ouvrir le menu"
+          >
+            <svg v-if="!mobileMenuOpen" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+            <svg v-else class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M6 18L18 6" />
+            </svg>
+          </button>
+        </div>
       </div>
+
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0 -translate-y-2"
+        enter-to-class="opacity-100 translate-y-0"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0 -translate-y-2"
+      >
+        <div v-if="mobileMenuOpen" class="border-t border-white/10 bg-background/95 backdrop-blur-md md:hidden">
+          <nav class="container-responsive flex flex-col gap-1 py-3" aria-label="Navigation mobile">
+            <RouterLink
+              v-for="item in navigation"
+              :key="item.to"
+              :to="item.to"
+              class="rounded-xl px-4 py-2.5 text-sm font-medium text-white/80 no-underline transition-colors hover:bg-white/10"
+              :class="route.path === item.to ? 'bg-white/10 text-white' : ''"
+            >
+              {{ item.name }}
+            </RouterLink>
+            <button
+              type="button"
+              class="flex items-center justify-between rounded-xl px-4 py-2.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10"
+              @click="toggleLocale"
+            >
+              <span>{{ t('app.language') }}</span>
+              <span class="text-xs uppercase tracking-wide text-primary">{{ locale }}</span>
+            </button>
+            <RouterLink
+              v-if="!auth.isAuthenticated.value"
+              to="/login"
+              class="mt-1 rounded-xl bg-primary px-4 py-2.5 text-center text-sm font-semibold text-background no-underline shadow-glow"
+            >
+              {{ t('auth.login') }}
+            </RouterLink>
+          </nav>
+        </div>
+      </Transition>
     </header>
 
     <main id="main" class="container-responsive py-10">
-      <RouterView />
+      <RouterView v-slot="{ Component }">
+        <Transition
+          enter-active-class="transition duration-300 ease-out"
+          enter-from-class="opacity-0 translate-y-2"
+          enter-to-class="opacity-100 translate-y-0"
+          mode="out-in"
+        >
+          <component :is="Component" />
+        </Transition>
+      </RouterView>
     </main>
 
     <footer class="border-t border-white/10 bg-background/80">
-      <div class="container-responsive py-6 text-sm text-white/60">&copy; {{ new Date().getFullYear() }} &middot; {{ t('app.name') }}</div>
+      <div class="container-responsive py-6 text-sm text-white/60">
+        &copy; {{ new Date().getFullYear() }} &middot; {{ t('app.name') }}
+      </div>
     </footer>
 
-    <!-- Global Toast Container -->
     <Teleport to="body">
-      <div class="fixed bottom-6 right-6 z-50 flex flex-col gap-2">
+      <div
+        class="pointer-events-none fixed inset-x-3 bottom-4 z-50 flex flex-col items-center gap-2 sm:inset-x-auto sm:bottom-6 sm:right-6 sm:items-end"
+      >
         <TransitionGroup
           enter-active-class="transition duration-200 ease-out"
           enter-from-class="translate-y-2 opacity-0"
@@ -198,21 +295,50 @@ const navigation = computed(() => {
           <div
             v-for="toast in toasts"
             :key="toast.id"
-            class="flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium shadow-lg backdrop-blur"
+            class="pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-xl border border-white/10 px-4 py-3 text-sm font-medium shadow-2xl backdrop-blur-md"
             :class="[
-              toast.type === 'success' ? 'bg-success/90 text-white' :
-              toast.type === 'error' ? 'bg-danger/90 text-white' :
-              'bg-white/20 text-white'
+              toast.type === 'success'
+                ? 'bg-success/90 text-white'
+                : toast.type === 'error'
+                  ? 'bg-danger/90 text-white'
+                  : 'bg-surface/95 text-white',
             ]"
             role="status"
           >
-            <span class="flex-1">{{ toast.message }}</span>
+            <svg
+              v-if="toast.type === 'success'"
+              class="mt-0.5 h-4 w-4 flex-shrink-0"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <svg
+              v-else-if="toast.type === 'error'"
+              class="mt-0.5 h-4 w-4 flex-shrink-0"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <span class="flex-1 leading-relaxed">{{ toast.message }}</span>
             <button
               type="button"
-              class="rounded-full p-0.5 opacity-70 transition hover:opacity-100"
+              class="-m-1 rounded-full p-1 opacity-70 transition-opacity hover:opacity-100"
+              aria-label="Fermer"
               @click="dismiss(toast.id)"
             >
-              <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+              <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
               </svg>
             </button>
@@ -221,7 +347,6 @@ const navigation = computed(() => {
       </div>
     </Teleport>
 
-    <!-- Click outside handler for user menu -->
     <div v-if="showUserMenu" class="fixed inset-0 z-40" @click="showUserMenu = false" />
   </div>
 </template>

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -3,11 +3,12 @@ import { computed } from 'vue';
 
 const props = withDefaults(
   defineProps<{
-    variant?: 'primary' | 'secondary' | 'ghost';
+    variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
     size?: 'sm' | 'md' | 'lg';
     block?: boolean;
     type?: 'button' | 'submit' | 'reset';
     disabled?: boolean;
+    loading?: boolean;
   }>(),
   {
     variant: 'primary',
@@ -15,23 +16,32 @@ const props = withDefaults(
     block: false,
     type: 'button',
     disabled: false,
+    loading: false,
   },
 );
 
 const classes = computed(() => {
   const base =
-    'inline-flex items-center justify-center gap-2 rounded-xl font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60';
+    'group relative inline-flex items-center justify-center gap-2 rounded-xl font-semibold transition-all duration-150 ease-out ' +
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background ' +
+    'disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:transform-none ' +
+    'active:scale-[0.98] select-none';
 
   const size = {
-    sm: 'px-3 py-2 text-sm',
-    md: 'px-4 py-2 text-base',
-    lg: 'px-6 py-3 text-lg',
+    sm: 'px-3.5 py-1.5 text-sm',
+    md: 'px-4 py-2.5 text-sm sm:text-base',
+    lg: 'px-6 py-3 text-base sm:text-lg',
   }[props.size];
 
   const variant = {
-    primary: 'bg-primary text-background hover:bg-primaryHover',
-    secondary: 'bg-white/10 text-white hover:bg-white/20',
-    ghost: 'bg-transparent text-primary hover:bg-white/10',
+    primary:
+      'bg-primary text-background shadow-glow hover:bg-primaryHover hover:shadow-glow-lg hover:-translate-y-0.5 focus-visible:ring-primary',
+    secondary:
+      'bg-white/10 text-white border border-white/10 hover:bg-white/15 hover:border-white/20 focus-visible:ring-white/50',
+    ghost:
+      'bg-transparent text-primary hover:bg-primary/10 focus-visible:ring-primary/60',
+    danger:
+      'bg-danger text-white hover:bg-danger/90 hover:-translate-y-0.5 focus-visible:ring-danger',
   }[props.variant];
 
   return [base, size, variant, props.block ? 'w-full' : ''].join(' ');
@@ -39,7 +49,24 @@ const classes = computed(() => {
 </script>
 
 <template>
-  <button :type="props.type" :disabled="props.disabled" :class="classes">
-    <slot />
+  <button
+    :type="props.type"
+    :disabled="props.disabled || props.loading"
+    :aria-busy="props.loading"
+    :class="classes"
+  >
+    <svg
+      v-if="props.loading"
+      class="h-4 w-4 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-opacity="0.25" stroke-width="3" />
+      <path d="M22 12a10 10 0 0 0-10-10" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+    </svg>
+    <span :class="props.loading ? 'opacity-90' : ''">
+      <slot />
+    </span>
   </button>
 </template>

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+
 defineOptions({ inheritAttrs: false });
 
 const model = defineModel<string | number | undefined>({ default: '' });
@@ -23,13 +25,20 @@ const props = withDefaults(
     disabled: false,
   },
 );
+
+const describedBy = computed(() => {
+  const ids: string[] = [];
+  if (props.hint) ids.push(`${props.id}-hint`);
+  if (props.error) ids.push(`${props.id}-error`);
+  return ids.length ? ids.join(' ') : undefined;
+});
 </script>
 
 <template>
-  <div class="space-y-1">
-    <label :for="props.id" class="text-sm font-medium">
+  <div class="space-y-1.5">
+    <label :for="props.id" class="flex items-center gap-1 text-sm font-medium text-white/90">
       {{ props.label }}
-      <span v-if="props.required" aria-hidden="true" class="text-danger">*</span>
+      <span v-if="props.required" aria-hidden="true" class="text-primary">*</span>
     </label>
     <input
       :id="props.id"
@@ -38,10 +47,32 @@ const props = withDefaults(
       :placeholder="props.placeholder"
       :required="props.required"
       :disabled="props.disabled"
+      :aria-invalid="props.error ? 'true' : undefined"
+      :aria-describedby="describedBy"
       v-bind="$attrs"
       class="rtl:text-right"
     />
-    <p v-if="props.hint" class="text-xs text-white/60">{{ props.hint }}</p>
-    <p v-if="props.error" class="text-xs text-danger" role="alert">{{ props.error }}</p>
+    <p
+      v-if="props.hint && !props.error"
+      :id="`${props.id}-hint`"
+      class="text-xs leading-relaxed text-white/60"
+    >
+      {{ props.hint }}
+    </p>
+    <p
+      v-if="props.error"
+      :id="`${props.id}-error`"
+      class="flex items-center gap-1.5 text-xs font-medium text-dangerSoft"
+      role="alert"
+    >
+      <svg class="h-3.5 w-3.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path
+          fill-rule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+          clip-rule="evenodd"
+        />
+      </svg>
+      {{ props.error }}
+    </p>
   </div>
 </template>

--- a/src/components/BaseSelect.vue
+++ b/src/components/BaseSelect.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+
 defineOptions({ inheritAttrs: false });
 
 const model = defineModel<string>({ default: '' });
@@ -10,25 +12,73 @@ const props = withDefaults(
     options: Array<{ label: string; value: string }>;
     placeholder?: string;
     error?: string;
+    hint?: string;
     required?: boolean;
   }>(),
   {
     placeholder: undefined,
     error: undefined,
+    hint: undefined,
     required: false,
   },
 );
+
+const describedBy = computed(() => {
+  const ids: string[] = [];
+  if (props.hint) ids.push(`${props.id}-hint`);
+  if (props.error) ids.push(`${props.id}-error`);
+  return ids.length ? ids.join(' ') : undefined;
+});
 </script>
 
 <template>
-  <div class="space-y-1">
-    <label :for="props.id">{{ props.label }}</label>
-    <select :id="props.id" v-model="model" :required="props.required" v-bind="$attrs">
-      <option v-if="props.placeholder" value="">{{ props.placeholder }}</option>
-      <option v-for="option in props.options" :key="option.value" :value="option.value">
-        {{ option.label }}
-      </option>
-    </select>
-    <p v-if="props.error" class="text-xs text-danger" role="alert">{{ props.error }}</p>
+  <div class="space-y-1.5">
+    <label :for="props.id" class="flex items-center gap-1 text-sm font-medium text-white/90">
+      {{ props.label }}
+      <span v-if="props.required" aria-hidden="true" class="text-primary">*</span>
+    </label>
+    <div class="relative">
+      <select
+        :id="props.id"
+        v-model="model"
+        :required="props.required"
+        :aria-invalid="props.error ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        v-bind="$attrs"
+        class="appearance-none pr-10 rtl:pl-10 rtl:pr-4"
+      >
+        <option v-if="props.placeholder" value="">{{ props.placeholder }}</option>
+        <option v-for="option in props.options" :key="option.value" :value="option.value">
+          {{ option.label }}
+        </option>
+      </select>
+      <svg
+        class="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50 rtl:left-3 rtl:right-auto"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M5.23 7.21a.75.75 0 011.06.02L10 11.06l3.71-3.83a.75.75 0 111.08 1.04l-4.25 4.39a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </div>
+    <p
+      v-if="props.hint && !props.error"
+      :id="`${props.id}-hint`"
+      class="text-xs leading-relaxed text-white/60"
+    >
+      {{ props.hint }}
+    </p>
+    <p
+      v-if="props.error"
+      :id="`${props.id}-error`"
+      class="text-xs font-medium text-dangerSoft"
+      role="alert"
+    >
+      {{ props.error }}
+    </p>
   </div>
 </template>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -27,22 +27,38 @@ function close() {
         leave-from="opacity-100"
         leave-to="opacity-0"
       >
-        <div class="fixed inset-0 bg-black/60" />
+        <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" />
       </TransitionChild>
 
       <div class="fixed inset-0 overflow-y-auto">
-        <div class="flex min-h-full items-center justify-center p-4">
+        <div class="flex min-h-full items-end justify-center p-4 sm:items-center">
           <TransitionChild
             as="template"
             enter="ease-out duration-200"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
+            enter-from="opacity-0 translate-y-6 sm:scale-95 sm:translate-y-0"
+            enter-to="opacity-100 translate-y-0 sm:scale-100"
             leave="ease-in duration-150"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
+            leave-from="opacity-100 translate-y-0 sm:scale-100"
+            leave-to="opacity-0 translate-y-6 sm:scale-95 sm:translate-y-0"
           >
-            <DialogPanel class="w-full max-w-lg transform rounded-2xl bg-surface/80 p-6 text-left shadow-xl">
-              <DialogTitle class="text-lg font-semibold text-white">{{ props.title }}</DialogTitle>
+            <DialogPanel
+              class="w-full max-w-lg transform rounded-2xl border border-white/10 bg-surface/90 p-6 text-left shadow-2xl backdrop-blur-md"
+            >
+              <div class="flex items-start justify-between gap-4">
+                <DialogTitle class="text-lg font-semibold text-white">{{ props.title }}</DialogTitle>
+                <button
+                  type="button"
+                  class="-m-1 rounded-full p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+                  aria-label="Fermer"
+                  @click="close"
+                >
+                  <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path
+                      d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"
+                    />
+                  </svg>
+                </button>
+              </div>
               <div class="mt-4 space-y-4">
                 <slot />
               </div>

--- a/src/components/PaymentStatusBadge.vue
+++ b/src/components/PaymentStatusBadge.vue
@@ -10,20 +10,33 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
-const variant = computed(() => {
+const config = computed(() => {
   switch (props.statut) {
     case 'paye':
-      return 'bg-success/20 text-success';
+      return {
+        classes: 'bg-success/15 text-successSoft ring-1 ring-inset ring-success/30',
+        dot: 'bg-success',
+      };
     case 'retard':
-      return 'bg-danger/20 text-danger';
+      return {
+        classes: 'bg-danger/15 text-dangerSoft ring-1 ring-inset ring-danger/30',
+        dot: 'bg-danger',
+      };
     default:
-      return 'bg-warning/20 text-warning';
+      return {
+        classes: 'bg-warning/15 text-warningSoft ring-1 ring-inset ring-warning/30',
+        dot: 'bg-warning',
+      };
   }
 });
 </script>
 
 <template>
-  <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold" :class="variant">
+  <span
+    class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold"
+    :class="config.classes"
+  >
+    <span class="badge-dot" :class="config.dot" aria-hidden="true" />
     {{ t(`statuses.${props.statut}`) }}
   </span>
 </template>

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -6,16 +6,60 @@ const props = defineProps<{
 </script>
 
 <template>
-  <ol class="flex flex-wrap items-center gap-3 text-sm" aria-label="Progression">
-    <li v-for="(step, index) in props.steps" :key="step" class="flex items-center gap-2">
+  <ol
+    class="flex flex-wrap items-center gap-x-2 gap-y-3 text-sm"
+    aria-label="Progression"
+    role="list"
+  >
+    <li
+      v-for="(step, index) in props.steps"
+      :key="step"
+      class="flex items-center gap-2"
+      :aria-current="index === props.current ? 'step' : undefined"
+    >
       <span
-        class="flex h-8 w-8 items-center justify-center rounded-full border"
-        :class="index < props.current ? 'border-primary bg-primary text-background' : 'border-white/20 text-white'"
+        class="relative flex h-8 w-8 items-center justify-center rounded-full border text-sm font-semibold transition-all duration-200"
+        :class="[
+          index < props.current
+            ? 'border-primary bg-primary text-background shadow-glow'
+            : index === props.current
+              ? 'border-primary text-primary animate-pulse-ring'
+              : 'border-white/15 text-white/50',
+        ]"
       >
-        {{ index + 1 }}
+        <svg
+          v-if="index < props.current"
+          class="h-4 w-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M16.704 5.29a1 1 0 010 1.42l-8 8a1 1 0 01-1.415 0l-4-4a1 1 0 111.415-1.415L8 12.585l7.29-7.295a1 1 0 011.414 0z"
+            clip-rule="evenodd"
+          />
+        </svg>
+        <span v-else>{{ index + 1 }}</span>
       </span>
-      <span class="font-medium" :class="index === props.current ? 'text-primary' : 'text-white/70'">{{ step }}</span>
-      <span v-if="index < props.steps.length - 1" class="mx-2 h-px w-10 bg-white/20" aria-hidden="true"></span>
+      <span
+        class="font-medium transition-colors"
+        :class="
+          index === props.current
+            ? 'text-white'
+            : index < props.current
+              ? 'text-white/70'
+              : 'text-white/50'
+        "
+      >
+        {{ step }}
+      </span>
+      <span
+        v-if="index < props.steps.length - 1"
+        aria-hidden="true"
+        class="mx-2 h-px w-8 transition-colors sm:w-12"
+        :class="index < props.current ? 'bg-primary/70' : 'bg-white/15'"
+      />
     </li>
   </ol>
 </template>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -1,25 +1,30 @@
 <script setup lang="ts">
-import { Transition } from 'vue';
+import { computed } from 'vue';
 
 const props = defineProps<{
   message: string;
   show: boolean;
   type?: 'success' | 'error' | 'info';
 }>();
+
+const config = computed(() => {
+  switch (props.type) {
+    case 'success':
+      return { classes: 'bg-success/90 text-white ring-success/40' };
+    case 'error':
+      return { classes: 'bg-danger/90 text-white ring-danger/40' };
+    default:
+      return { classes: 'bg-surface/95 text-white ring-white/10' };
+  }
+});
 </script>
 
 <template>
-  <Transition name="fade" mode="out-in">
+  <Transition name="toast" mode="out-in">
     <div
       v-if="props.show"
-      class="fixed bottom-6 inset-x-0 mx-auto w-fit rounded-full px-6 py-3 text-sm font-medium shadow-lg"
-      :class="[
-        props.type === 'success'
-          ? 'bg-success/90 text-white'
-          : props.type === 'error'
-            ? 'bg-danger/90 text-white'
-            : 'bg-white/20 text-white',
-      ]"
+      class="fixed inset-x-4 bottom-4 z-50 mx-auto w-fit max-w-[calc(100%-2rem)] rounded-full px-5 py-2.5 text-sm font-medium shadow-2xl ring-1 backdrop-blur-md sm:bottom-6"
+      :class="config.classes"
       role="status"
     >
       {{ props.message }}
@@ -28,13 +33,16 @@ const props = defineProps<{
 </template>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
+.toast-enter-active,
+.toast-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
-.fade-enter-from,
-.fade-leave-to {
+.toast-enter-from,
+.toast-leave-to {
   opacity: 0;
+  transform: translateY(8px);
 }
 </style>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -22,44 +22,67 @@ const scrollToDemo = () => {
   <div class="space-y-20 pb-12">
     <!-- Hero Section -->
     <section class="relative overflow-hidden">
-      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-primary/5" />
-      <div class="relative px-4 py-16 text-center sm:px-6 sm:py-24 lg:py-32">
-        <h1 class="mx-auto max-w-4xl text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
-          <span class="bg-gradient-to-r from-white via-white to-white/80 bg-clip-text text-transparent">
+      <div class="pointer-events-none absolute inset-0 bg-hero-radial" aria-hidden="true" />
+      <div
+        class="pointer-events-none absolute -top-24 left-1/2 h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-primary/20 blur-3xl"
+        aria-hidden="true"
+      />
+      <div class="relative px-4 py-16 text-center sm:px-6 sm:py-24 lg:py-28">
+        <div
+          class="mx-auto inline-flex animate-fade-in items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary"
+        >
+          <span class="relative flex h-2 w-2">
+            <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-70" />
+            <span class="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+          </span>
+          {{ t('app.tagline') }}
+        </div>
+        <h1 class="mx-auto mt-6 max-w-4xl animate-fade-in-up text-balance text-4xl font-bold leading-tight tracking-tight sm:text-5xl lg:text-6xl">
+          <span class="bg-gradient-to-br from-white via-white to-white/60 bg-clip-text text-transparent">
             {{ t('landing.hero.title') }}
           </span>
         </h1>
-        <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-white/70 sm:text-xl">
+        <p
+          class="mx-auto mt-6 max-w-2xl animate-fade-in-up text-pretty text-lg leading-8 text-white/70 sm:text-xl"
+          style="animation-delay: 80ms"
+        >
           {{ t('landing.hero.subtitle') }}
         </p>
-        <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
+        <div
+          class="mt-10 flex animate-fade-in-up flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center sm:gap-4"
+          style="animation-delay: 160ms"
+        >
           <RouterLink :to="createLink">
-            <BaseButton size="lg" class="shadow-lg shadow-primary/20 transition-all hover:shadow-xl hover:shadow-primary/30">
+            <BaseButton size="lg" block>
               {{ t('landing.hero.cta_primary') }}
+              <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path
+                  fill-rule="evenodd"
+                  d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  clip-rule="evenodd"
+                />
+              </svg>
             </BaseButton>
           </RouterLink>
-          <BaseButton size="lg" variant="secondary" @click="scrollToDemo">
+          <BaseButton size="lg" variant="secondary" block @click="scrollToDemo">
             {{ t('landing.hero.cta_secondary') }}
           </BaseButton>
         </div>
 
         <!-- Stats Section -->
-        <div class="mx-auto mt-16 grid max-w-4xl grid-cols-2 gap-6 sm:gap-8 lg:grid-cols-4">
-          <div class="rounded-2xl border border-white/10 bg-surface/50 p-6 backdrop-blur-sm">
-            <div class="text-3xl font-bold text-primary sm:text-4xl">{{ t('landing.stats.stat1_value') }}</div>
-            <div class="mt-2 text-sm text-white/60">{{ t('landing.stats.stat1_label') }}</div>
-          </div>
-          <div class="rounded-2xl border border-white/10 bg-surface/50 p-6 backdrop-blur-sm">
-            <div class="text-3xl font-bold text-primary sm:text-4xl">{{ t('landing.stats.stat2_value') }}</div>
-            <div class="mt-2 text-sm text-white/60">{{ t('landing.stats.stat2_label') }}</div>
-          </div>
-          <div class="rounded-2xl border border-white/10 bg-surface/50 p-6 backdrop-blur-sm">
-            <div class="text-3xl font-bold text-primary sm:text-4xl">{{ t('landing.stats.stat3_value') }}</div>
-            <div class="mt-2 text-sm text-white/60">{{ t('landing.stats.stat3_label') }}</div>
-          </div>
-          <div class="rounded-2xl border border-white/10 bg-surface/50 p-6 backdrop-blur-sm">
-            <div class="text-3xl font-bold text-primary sm:text-4xl">{{ t('landing.stats.stat4_value') }}</div>
-            <div class="mt-2 text-sm text-white/60">{{ t('landing.stats.stat4_label') }}</div>
+        <div
+          class="mx-auto mt-16 grid max-w-4xl animate-fade-in-up grid-cols-2 gap-4 sm:gap-6 lg:grid-cols-4"
+          style="animation-delay: 240ms"
+        >
+          <div
+            v-for="n in 4"
+            :key="n"
+            class="group rounded-2xl border border-white/10 bg-surface/50 p-5 backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-surface/70 hover:shadow-glow sm:p-6"
+          >
+            <div class="gradient-text text-3xl font-bold sm:text-4xl">
+              {{ t(`landing.stats.stat${n}_value`) }}
+            </div>
+            <div class="mt-2 text-sm text-white/60">{{ t(`landing.stats.stat${n}_label`) }}</div>
           </div>
         </div>
       </div>
@@ -75,7 +98,7 @@ const scrollToDemo = () => {
 
         <div class="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <!-- Feature 1: Secure & Local -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -91,7 +114,7 @@ const scrollToDemo = () => {
           </article>
 
           <!-- Feature 2: Multilingual -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -107,7 +130,7 @@ const scrollToDemo = () => {
           </article>
 
           <!-- Feature 3: Simple & Efficient -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -123,7 +146,7 @@ const scrollToDemo = () => {
           </article>
 
           <!-- Feature 4: Payment Integration -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -139,7 +162,7 @@ const scrollToDemo = () => {
           </article>
 
           <!-- Feature 5: Access Management -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -155,7 +178,7 @@ const scrollToDemo = () => {
           </article>
 
           <!-- Feature 6: Open Source -->
-          <article class="group card space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article class="group card-interactive space-y-4">
             <div class="inline-flex rounded-xl bg-primary/10 p-3">
               <svg class="h-8 w-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -383,7 +406,11 @@ const scrollToDemo = () => {
         </div>
 
         <div v-if="featured.length > 0" class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          <article v-for="daret in featured" :key="daret.id" class="card group space-y-4 transition-all hover:border-primary/50 hover:shadow-lg hover:shadow-primary/10">
+          <article
+            v-for="daret in featured"
+            :key="daret.id"
+            class="card-interactive group space-y-4"
+          >
             <div class="flex items-start justify-between">
               <h3 class="text-xl font-semibold">{{ daret.nom }}</h3>
               <span class="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
@@ -426,10 +453,17 @@ const scrollToDemo = () => {
           <div class="rounded-3xl bg-background p-8 text-center sm:p-12">
             <h2 class="text-3xl font-bold sm:text-4xl">{{ t('landing.cta.title') }}</h2>
             <p class="mt-4 text-lg text-white/70">{{ t('landing.cta.subtitle') }}</p>
-            <div class="mt-8">
+            <div class="mt-8 flex justify-center">
               <RouterLink :to="createLink">
-                <BaseButton size="lg" class="shadow-lg shadow-primary/20 transition-all hover:shadow-xl hover:shadow-primary/30">
+                <BaseButton size="lg">
                   {{ t('landing.cta.button') }}
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path
+                      fill-rule="evenodd"
+                      d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                      clip-rule="evenodd"
+                    />
+                  </svg>
                 </BaseButton>
               </RouterLink>
             </div>

--- a/src/pages/inscription.vue
+++ b/src/pages/inscription.vue
@@ -61,10 +61,17 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="mx-auto max-w-md py-12">
+  <div class="mx-auto max-w-md py-12 animate-fade-in-up">
     <div class="card p-8">
-      <h1 class="mb-2 text-2xl font-bold">Creer un compte</h1>
-      <p class="mb-8 text-sm text-white/60">Inscrivez-vous pour creer ou rejoindre un Daret</p>
+      <div class="mb-8 text-center">
+        <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-primary ring-1 ring-inset ring-primary/30">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zM3 19.235v-.11a6.375 6.375 0 0112.75 0v.109A12.318 12.318 0 019.374 21c-2.331 0-4.512-.645-6.374-1.766z" />
+          </svg>
+        </div>
+        <h1 class="text-2xl font-bold">Creer un compte</h1>
+        <p class="mt-2 text-sm text-white/60">Inscrivez-vous pour creer ou rejoindre un Daret</p>
+      </div>
 
       <form @submit.prevent="handleSubmit" class="space-y-4">
         <div class="grid grid-cols-2 gap-4">
@@ -126,21 +133,14 @@ async function handleSubmit() {
           autocomplete="new-password"
         />
 
-        <BaseButton type="submit" variant="primary" block :disabled="submitting">
-          <span v-if="submitting" class="flex items-center gap-2">
-            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" class="opacity-25" />
-              <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" class="opacity-75" />
-            </svg>
-            Inscription...
-          </span>
-          <span v-else>Creer mon compte</span>
+        <BaseButton type="submit" variant="primary" block :loading="submitting">
+          {{ submitting ? 'Inscription...' : 'Creer mon compte' }}
         </BaseButton>
       </form>
 
       <p class="mt-6 text-center text-sm text-white/60">
         Deja un compte ?
-        <RouterLink to="/login" class="font-medium text-primary hover:text-primaryHover">
+        <RouterLink to="/login" class="font-semibold text-primary no-underline transition-colors hover:text-primaryHover">
           Se connecter
         </RouterLink>
       </p>

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -45,10 +45,17 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="mx-auto max-w-md py-12">
+  <div class="mx-auto max-w-md py-12 animate-fade-in-up">
     <div class="card p-8">
-      <h1 class="mb-2 text-2xl font-bold">{{ t('auth.login') }}</h1>
-      <p class="mb-8 text-sm text-white/60">Connectez-vous pour acceder a vos Darets</p>
+      <div class="mb-8 text-center">
+        <div class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-primary ring-1 ring-inset ring-primary/30">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.5 20.25c0-3.728 3.022-6.75 6.75-6.75h1.5c3.728 0 6.75 3.022 6.75 6.75" />
+          </svg>
+        </div>
+        <h1 class="text-2xl font-bold">{{ t('auth.login') }}</h1>
+        <p class="mt-2 text-sm text-white/60">Connectez-vous pour acceder a vos Darets</p>
+      </div>
 
       <form @submit.prevent="handleSubmit" class="space-y-5">
         <BaseInput
@@ -59,6 +66,7 @@ async function handleSubmit() {
           :error="errors.email"
           required
           autocomplete="email"
+          placeholder="you@example.com"
         />
 
         <BaseInput
@@ -69,23 +77,17 @@ async function handleSubmit() {
           :error="errors.password"
           required
           autocomplete="current-password"
+          placeholder="********"
         />
 
-        <BaseButton type="submit" variant="primary" block :disabled="submitting">
-          <span v-if="submitting" class="flex items-center gap-2">
-            <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" class="opacity-25" />
-              <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" class="opacity-75" />
-            </svg>
-            Connexion...
-          </span>
-          <span v-else>{{ t('auth.login') }}</span>
+        <BaseButton type="submit" variant="primary" block :loading="submitting">
+          {{ submitting ? 'Connexion...' : t('auth.login') }}
         </BaseButton>
       </form>
 
       <p class="mt-6 text-center text-sm text-white/60">
         Pas encore de compte ?
-        <RouterLink to="/inscription" class="font-medium text-primary hover:text-primaryHover">
+        <RouterLink to="/inscription" class="font-semibold text-primary no-underline transition-colors hover:text-primaryHover">
           Creer un compte
         </RouterLink>
       </p>

--- a/src/pages/mes-darets.vue
+++ b/src/pages/mes-darets.vue
@@ -49,13 +49,13 @@ function statusLabel(etat: string) {
 
 function statusColor(etat: string) {
   const map: Record<string, string> = {
-    RECRUTEMENT: 'bg-blue-500/20 text-blue-400',
-    VERROUILLEE: 'bg-yellow-500/20 text-yellow-400',
-    ACTIVE: 'bg-green-500/20 text-green-400',
-    TERMINEE: 'bg-white/10 text-white/50',
-    ANNULEE: 'bg-red-500/20 text-red-400',
+    RECRUTEMENT: 'bg-blue-500/15 text-blue-300 ring-1 ring-inset ring-blue-500/30',
+    VERROUILLEE: 'bg-warning/15 text-warningSoft ring-1 ring-inset ring-warning/30',
+    ACTIVE: 'bg-success/15 text-successSoft ring-1 ring-inset ring-success/30',
+    TERMINEE: 'bg-white/10 text-white/60 ring-1 ring-inset ring-white/10',
+    ANNULEE: 'bg-danger/15 text-dangerSoft ring-1 ring-inset ring-danger/30',
   }
-  return map[etat] || 'bg-white/10 text-white/50'
+  return map[etat] || 'bg-white/10 text-white/60 ring-1 ring-inset ring-white/10'
 }
 
 function formatCurrency(amount: number, devise: string) {
@@ -83,27 +83,38 @@ function formatCurrency(amount: number, devise: string) {
     </div>
 
     <!-- Loading -->
-    <div v-if="loading" class="space-y-4">
-      <div v-for="i in 3" :key="i" class="card animate-pulse p-6">
-        <div class="h-5 w-48 rounded bg-white/10" />
-        <div class="mt-3 h-4 w-32 rounded bg-white/5" />
+    <div v-if="loading" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div v-for="i in 3" :key="i" class="card space-y-3 p-5">
+        <div class="skeleton h-5 w-48" />
+        <div class="skeleton h-3 w-32" />
+        <div class="mt-4 space-y-2">
+          <div class="skeleton h-3 w-full" />
+          <div class="skeleton h-3 w-2/3" />
+        </div>
       </div>
     </div>
 
     <!-- Empty State -->
-    <div v-else-if="darets.length === 0" class="card flex flex-col items-center py-16 text-center">
-      <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-        <svg class="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+    <div
+      v-else-if="darets.length === 0"
+      class="card flex flex-col items-center py-20 text-center animate-fade-in-up"
+    >
+      <div class="mb-5 flex h-20 w-20 items-center justify-center rounded-full bg-primary/10 ring-1 ring-inset ring-primary/30">
+        <svg class="h-10 w-10 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
         </svg>
       </div>
-      <h2 class="mb-2 text-lg font-semibold">Aucun Daret</h2>
-      <p class="mb-6 max-w-sm text-sm text-white/60">
-        Vous n'avez pas encore de Daret. Creez-en un ou rejoignez un Daret existant avec un code d'invitation.
+      <h2 class="mb-2 text-xl font-semibold">Aucun Daret pour le moment</h2>
+      <p class="mb-6 max-w-md text-sm leading-relaxed text-white/70">
+        Lancez votre premiere cagnotte rotative en quelques minutes ou rejoignez un Daret existant avec un code d'invitation.
       </p>
-      <div class="flex gap-3">
-        <BaseButton variant="secondary" @click="router.push('/daret/rejoindre')">Rejoindre un Daret</BaseButton>
-        <BaseButton variant="primary" @click="router.push('/daret/creer')">Creer un Daret</BaseButton>
+      <div class="flex flex-col gap-3 sm:flex-row">
+        <BaseButton variant="secondary" @click="router.push('/daret/rejoindre')">
+          Rejoindre un Daret
+        </BaseButton>
+        <BaseButton variant="primary" @click="router.push('/daret/creer')">
+          Creer un Daret
+        </BaseButton>
       </div>
     </div>
 
@@ -117,7 +128,7 @@ function formatCurrency(amount: number, devise: string) {
             v-for="daret in activeDarets"
             :key="daret.id"
             :to="`/daret/${daret.id}`"
-            class="card group p-5 transition hover:border-primary/30"
+            class="card group p-5 no-underline transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-glow"
           >
             <div class="mb-3 flex items-center justify-between">
               <h3 class="font-semibold group-hover:text-primary">{{ daret.nom }}</h3>
@@ -151,7 +162,7 @@ function formatCurrency(amount: number, devise: string) {
             v-for="daret in recruitingDarets"
             :key="daret.id"
             :to="`/daret/${daret.id}`"
-            class="card group p-5 transition hover:border-primary/30"
+            class="card group p-5 no-underline transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-glow"
           >
             <div class="mb-3 flex items-center justify-between">
               <h3 class="font-semibold group-hover:text-primary">{{ daret.nom }}</h3>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -5,38 +5,64 @@
 @layer base {
   :root {
     color-scheme: dark;
+    --scroll-padding: 5rem;
   }
 
   html {
     @apply bg-background text-white antialiased;
+    scroll-padding-top: var(--scroll-padding);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
   }
 
   body {
     @apply min-h-screen bg-background text-white;
+    background-image:
+      radial-gradient(60% 60% at 20% 0%, rgba(255, 179, 0, 0.08) 0%, rgba(255, 179, 0, 0) 60%),
+      radial-gradient(50% 50% at 100% 20%, rgba(59, 130, 246, 0.06) 0%, rgba(59, 130, 246, 0) 60%);
+    background-attachment: fixed;
   }
 
-  h1,
-  h2,
-  h3,
+  h1 {
+    @apply font-display text-3xl font-bold leading-tight tracking-tight text-white sm:text-4xl;
+  }
+
+  h2 {
+    @apply font-display text-2xl font-bold leading-tight tracking-tight text-white sm:text-3xl;
+  }
+
+  h3 {
+    @apply font-display text-lg font-semibold leading-snug tracking-tight text-white sm:text-xl;
+  }
+
   h4,
   h5,
   h6 {
-    @apply font-semibold tracking-tight text-white;
+    @apply font-display font-semibold tracking-tight text-white;
+  }
+
+  p {
+    @apply leading-relaxed;
   }
 
   a {
-    @apply text-primary underline-offset-4 transition hover:text-primaryHover;
+    @apply text-primary underline-offset-4 transition-colors hover:text-primaryHover;
   }
 
   label {
-    @apply block text-sm font-medium text-white;
+    @apply block text-sm font-medium text-white/90;
   }
 
   input,
   select,
   textarea {
-    @apply w-full rounded-lg border border-white/10 bg-surface/60 px-4 py-2 text-base text-white shadow-sm transition
-      placeholder:text-white/40 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary;
+    @apply w-full rounded-xl border border-white/10 bg-surface/60 px-4 py-2.5 text-base text-white shadow-sm transition-all duration-150
+      placeholder:text-white/40
+      hover:border-white/20
+      focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40
+      disabled:cursor-not-allowed disabled:opacity-60
+      aria-[invalid=true]:border-danger aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-danger/30;
   }
 
   button {
@@ -46,14 +72,70 @@
   ::selection {
     @apply bg-primary text-background;
   }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    @apply bg-transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-white/10;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-white/20;
+  }
 }
 
 @layer components {
   .card {
-    @apply rounded-2xl border border-white/10 bg-surface/60 p-6 shadow-xl backdrop-blur supports-backdrop:bg-surface/30;
+    @apply rounded-2xl border border-white/10 bg-surface/60 p-6 shadow-card backdrop-blur-sm supports-backdrop:bg-surface/40 transition-colors duration-200;
+  }
+
+  .card-interactive {
+    @apply card hover:border-primary/40 hover:bg-surface/70 hover:shadow-glow;
   }
 
   .container-responsive {
     @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
+  }
+
+  .gradient-text {
+    @apply bg-gradient-to-r from-primary via-primarySoft to-primary bg-clip-text text-transparent;
+  }
+
+  .chip {
+    @apply inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-medium text-white/80;
+  }
+
+  .badge-dot {
+    @apply inline-block h-1.5 w-1.5 rounded-full;
+  }
+
+  .skeleton {
+    @apply relative overflow-hidden rounded-md bg-white/5;
+  }
+
+  .skeleton::after {
+    content: '';
+    @apply absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-white/10 to-transparent;
+  }
+
+  .link-subtle {
+    @apply text-white/70 no-underline transition-colors hover:text-white;
+  }
+}
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
+  }
+
+  .text-pretty {
+    text-wrap: pretty;
   }
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,18 +8,60 @@ module.exports = {
       colors: {
         primary: '#FFB300',
         primaryHover: '#E6A100',
+        primarySoft: '#FFD166',
         background: '#0B0F1A',
+        backgroundElevated: '#0F1524',
         surface: '#111827',
-        success: '#16A34A',
+        surfaceHover: '#1A2337',
+        success: '#22C55E',
+        successSoft: '#4ADE80',
         warning: '#F59E0B',
-        danger: '#DC2626',
+        warningSoft: '#FBBF24',
+        danger: '#EF4444',
+        dangerSoft: '#F87171',
       },
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
         arabic: ['"Noto Kufi Arabic"', ...defaultTheme.fontFamily.sans],
+        display: ['Inter', ...defaultTheme.fontFamily.sans],
       },
       screens: {
         xs: '420px',
+      },
+      boxShadow: {
+        glow: '0 20px 45px -18px rgba(255, 179, 0, 0.45)',
+        'glow-lg': '0 30px 60px -20px rgba(255, 179, 0, 0.55)',
+        card: '0 14px 45px -25px rgba(0, 0, 0, 0.8)',
+      },
+      backgroundImage: {
+        'hero-radial':
+          'radial-gradient(60% 60% at 50% 0%, rgba(255,179,0,0.18) 0%, rgba(255,179,0,0) 70%)',
+        'grid-fade':
+          'linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0) 100%)',
+      },
+      keyframes: {
+        'fade-in-up': {
+          '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        shimmer: {
+          '100%': { transform: 'translateX(100%)' },
+        },
+        'pulse-ring': {
+          '0%': { boxShadow: '0 0 0 0 rgba(255,179,0,0.45)' },
+          '70%': { boxShadow: '0 0 0 12px rgba(255,179,0,0)' },
+          '100%': { boxShadow: '0 0 0 0 rgba(255,179,0,0)' },
+        },
+      },
+      animation: {
+        'fade-in-up': 'fade-in-up 420ms ease-out both',
+        'fade-in': 'fade-in 300ms ease-out both',
+        shimmer: 'shimmer 1.6s linear infinite',
+        'pulse-ring': 'pulse-ring 1.8s cubic-bezier(0.66, 0, 0, 1) infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary

Design system + deploy refresh so the app looks modern and ships publicly from GitHub Actions.

### UI / UX
- **Design tokens** (`tailwind.config.cjs`, `src/styles/tailwind.css`): glow shadows, hero-radial/grid backgrounds, staggered fade-in & pulse-ring animations, balanced typography scale, custom scrollbar, reusable `card-interactive`, `gradient-text`, `chip`, `skeleton` utilities, readable contrast for labels/hints.
- **Components**:
  - `BaseButton` — loading spinner, lift + glow hover, scale-active, new `danger` variant.
  - `BaseInput` / `BaseSelect` — `aria-invalid`, hint/error ids, inline error icon, RTL-aware chevron, hover states.
  - `Modal` — backdrop blur, dedicated close button, mobile bottom-sheet transition.
  - `Stepper` — animated active step with check icon + pulse ring.
  - `PaymentStatusBadge` — dot + ring tokens for WCAG-friendly contrast.
  - `Toast` (local + global) — responsive (mobile full-width, desktop bottom-right), success/error icons, backdrop blur.
- **Pages**:
  - `index.vue` — new hero (badge, gradient heading, staggered CTAs with chevron), hover-lift stat cards, feature/payment/role cards reuse `card-interactive`.
  - `login.vue` / `inscription.vue` — avatar header, loading button via `BaseButton :loading`.
  - `mes-darets.vue` — upgraded empty state, shimmer skeletons, hover-lift cards, WCAG status colors.
- `App.vue` — sticky/blurred header, mobile menu, route transition, auth avatar ring and toast stack refactor.

### GitHub Pages deploy
- `.github/workflows/deploy.yml` now sets `VITE_BASE_URL=/Tonti/`, uses `npm ci` + npm cache, runs `actions/configure-pages@v5`, adds `concurrency: pages`.
- `scripts/postbuild.mjs` also writes `.nojekyll` next to `404.html`.
- `index.html` uses relative favicon (Vite rewrites with base) and declares `theme-color`.

Result: site builds with absolute `/Tonti/assets/*` paths and deploys to `https://naciro2010.github.io/Tonti/` on every push to `main`.

## Test plan
- [x] `npm ci`
- [x] `npm run test:run` — 27/27 passing
- [x] `VITE_BASE_URL=/Tonti/ npm run build` — produces `dist/index.html` with `/Tonti/assets/*`, plus `dist/404.html` and `dist/.nojekyll`
- [ ] After merge: GitHub Actions `Deploy GitHub Pages` workflow is green and the site is reachable at https://naciro2010.github.io/Tonti/
