### PR TITLE
feat(ui): polish dashboard, wizard and join surfaces

### DIFF
--- a/src/components/ContributionGrid.vue
+++ b/src/components/ContributionGrid.vue
@@ -30,6 +30,19 @@ const paymentMap = computed(() => {
   return map;
 });
 
+function statutOf(membreId: string): PaiementStatut {
+  return paymentMap.get(membreId)?.statut ?? 'a_payer';
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
 function mark(membreId: string, statut: PaiementStatut) {
   emit('update', { membreId, statut });
 }
@@ -40,21 +53,24 @@ function mark(membreId: string, statut: PaiementStatut) {
     <div
       v-for="membre in props.membres"
       :key="membre.id"
-      class="grid gap-2 rounded-xl border border-white/10 bg-white/5 p-4 sm:grid-cols-[1fr_auto] sm:items-center"
+      class="group grid gap-3 rounded-2xl border border-white/10 bg-surface/40 p-4 transition-colors hover:border-white/20 hover:bg-surface/60 sm:grid-cols-[auto_1fr_auto] sm:items-center"
     >
-      <div>
-        <p class="font-semibold">{{ membre.nom }}</p>
-        <p v-if="membre.contact" class="text-xs text-white/60">{{ membre.contact }}</p>
-        <PaymentStatusBadge
-          class="mt-2"
-          :statut="paymentMap.get(membre.id)?.statut ?? 'a_payer'"
-        />
+      <div
+        class="hidden h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/15 text-sm font-bold text-primary ring-1 ring-inset ring-primary/25 sm:flex"
+        aria-hidden="true"
+      >
+        {{ initials(membre.nom) }}
+      </div>
+      <div class="space-y-1.5">
+        <p class="font-semibold leading-tight text-white">{{ membre.nom }}</p>
+        <p v-if="membre.contact" class="text-xs text-white/55">{{ membre.contact }}</p>
+        <PaymentStatusBadge :statut="statutOf(membre.id)" />
       </div>
       <div class="flex flex-wrap items-center gap-2 justify-start sm:justify-end">
         <BaseButton
           type="button"
           size="sm"
-          variant="secondary"
+          :variant="statutOf(membre.id) === 'paye' ? 'primary' : 'secondary'"
           :disabled="props.disabled"
           @click="mark(membre.id, 'paye')"
         >
@@ -63,7 +79,7 @@ function mark(membreId: string, statut: PaiementStatut) {
         <BaseButton
           type="button"
           size="sm"
-          variant="ghost"
+          :variant="statutOf(membre.id) === 'retard' ? 'danger' : 'ghost'"
           :disabled="props.disabled"
           @click="mark(membre.id, 'retard')"
         >

--- a/src/components/InviteBanner.vue
+++ b/src/components/InviteBanner.vue
@@ -23,23 +23,93 @@ async function copy() {
     console.warn('Copy failed', error);
   }
 }
+
+async function share() {
+  if (typeof navigator !== 'undefined' && 'share' in navigator) {
+    try {
+      await navigator.share({
+        title: 'Tonti · Rejoindre un Daret',
+        url: props.invitationUrl,
+      });
+      return;
+    } catch (error) {
+      /* user cancelled */
+    }
+  }
+  copy();
+}
+
+const canShare =
+  typeof navigator !== 'undefined' && 'share' in navigator;
 </script>
 
 <template>
-  <section class="card grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
-    <div class="space-y-2">
-      <h3 class="text-lg font-semibold">{{ t('invite.title') }}</h3>
-      <p class="text-sm text-white/70">{{ t('invite.share') }}</p>
-      <div class="flex flex-wrap items-center gap-3">
-        <span class="truncate rounded-lg bg-white/10 px-3 py-2 text-sm">{{ props.invitationUrl }}</span>
-        <BaseButton type="button" size="sm" @click="copy">{{ copied ? t('invite.copied') : t('actions.copyLink') }}</BaseButton>
+  <section class="card relative overflow-hidden">
+    <div
+      class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-gradient-to-l from-primary/10 via-primary/5 to-transparent"
+      aria-hidden="true"
+    />
+    <div class="relative grid gap-6 sm:grid-cols-[1fr_auto] sm:items-center">
+      <div class="space-y-4">
+        <div class="space-y-1.5">
+          <h3 class="flex items-center gap-2 text-lg font-semibold">
+            <svg class="h-5 w-5 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
+            </svg>
+            {{ t('invite.title') }}
+          </h3>
+          <p class="text-sm text-white/70">{{ t('invite.share') }}</p>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <div class="flex flex-1 min-w-0 items-center gap-2 rounded-xl border border-white/10 bg-surface/60 px-3 py-2">
+            <svg class="h-4 w-4 flex-shrink-0 text-white/50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" />
+            </svg>
+            <span class="truncate text-sm text-white/80">{{ props.invitationUrl }}</span>
+          </div>
+          <BaseButton type="button" size="sm" :variant="copied ? 'primary' : 'secondary'" @click="copy">
+            <svg
+              v-if="copied"
+              class="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M16.704 5.29a1 1 0 010 1.42l-8 8a1 1 0 01-1.415 0l-4-4a1 1 0 111.415-1.415L8 12.585l7.29-7.295a1 1 0 011.414 0z"
+                clip-rule="evenodd"
+              />
+            </svg>
+            <svg
+              v-else
+              class="h-4 w-4"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M8 2a1 1 0 011-1h4a1 1 0 011 1v1h2a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V5a2 2 0 012-2h2V2zm2 0v1h4V2h-4z" />
+            </svg>
+            {{ copied ? t('invite.copied') : t('actions.copyLink') }}
+          </BaseButton>
+          <BaseButton v-if="canShare" type="button" size="sm" variant="ghost" @click="share">
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M15 8a3 3 0 10-2.977-2.63l-4.94 2.47a3 3 0 100 4.319l4.94 2.47a3 3 0 10.895-1.789l-4.94-2.47a3.027 3.027 0 000-.74l4.94-2.47C13.456 7.68 14.19 8 15 8z" />
+            </svg>
+            Partager
+          </BaseButton>
+        </div>
+      </div>
+      <div class="flex justify-center sm:justify-end">
+        <div class="rounded-2xl bg-white p-3 shadow-lg">
+          <QrcodeVue
+            :value="props.invitationUrl"
+            :size="120"
+            level="M"
+            :aria-label="t('invite.qrAlt')"
+          />
+        </div>
       </div>
     </div>
-    <QrcodeVue
-      :value="props.invitationUrl"
-      :size="120"
-      class="mx-auto rounded-xl bg-white p-2"
-      :aria-label="t('invite.qrAlt')"
-    />
   </section>
 </template>

--- a/src/components/RoundHeader.vue
+++ b/src/components/RoundHeader.vue
@@ -22,35 +22,107 @@ const daysLabel = computed(() =>
     ? t('dashboard.today')
     : t('dashboard.daysRemaining', { count: props.daysRemaining })
 );
+
+const progress = computed(() =>
+  props.totalRounds > 0 ? Math.round((props.roundIndex / props.totalRounds) * 100) : 0,
+);
+
+const urgency = computed(() => {
+  if (props.daysRemaining <= 0) return 'text-dangerSoft';
+  if (props.daysRemaining <= 3) return 'text-warningSoft';
+  return 'text-successSoft';
+});
+
+const initials = computed(() => {
+  if (!props.receveur?.nom) return '?';
+  return props.receveur.nom
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+});
 </script>
 
 <template>
-  <header class="card space-y-4">
-    <div class="flex flex-wrap items-center justify-between gap-3">
-      <div>
-        <p class="text-sm uppercase tracking-wide text-white/60">{{ t('dashboard.round', { current: props.roundIndex, total: props.totalRounds }) }}</p>
-        <h2 class="text-2xl font-semibold">{{ props.receveur?.nom }}</h2>
+  <header class="card relative overflow-hidden">
+    <div
+      class="pointer-events-none absolute -top-20 right-0 h-48 w-48 rounded-full bg-primary/20 blur-3xl"
+      aria-hidden="true"
+    />
+    <div class="relative space-y-6">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <div class="flex items-center gap-4">
+          <div
+            class="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-xl font-bold text-primary ring-1 ring-inset ring-primary/30"
+            aria-hidden="true"
+          >
+            {{ initials }}
+          </div>
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+              {{ t('dashboard.round', { current: props.roundIndex, total: props.totalRounds }) }}
+            </p>
+            <h2 class="mt-0.5 text-2xl font-bold tracking-tight text-white sm:text-3xl">
+              {{ props.receveur?.nom ?? '—' }}
+            </h2>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white/80 transition-colors hover:border-primary/40 hover:bg-primary/10 hover:text-primary"
+          @click="toggleDevise"
+        >
+          <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M4 6a2 2 0 012-2h8a2 2 0 012 2v1H4V6z" />
+            <path fill-rule="evenodd" d="M16 9H4v5a2 2 0 002 2h8a2 2 0 002-2V9zM6 12a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd" />
+          </svg>
+          {{ t('actions.toggleCurrency') }}
+        </button>
       </div>
-      <button
-        type="button"
-        class="text-sm text-primary underline-offset-4 hover:underline"
-        @click="toggleDevise"
-      >
-        {{ t('actions.toggleCurrency') }}
-      </button>
-    </div>
-    <div class="grid gap-4 sm:grid-cols-3">
-      <div>
-        <p class="text-xs uppercase tracking-wide text-white/50">{{ t('dashboard.receiver') }}</p>
-        <p class="text-lg font-semibold">{{ props.receveur?.nom ?? '—' }}</p>
+
+      <div class="grid gap-4 sm:grid-cols-3">
+        <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-white/50">
+            {{ t('dashboard.receiver') }}
+          </p>
+          <p class="mt-1 text-lg font-bold text-white">{{ props.receveur?.nom ?? '—' }}</p>
+        </div>
+        <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-white/50">
+            {{ t('dashboard.total') }}
+          </p>
+          <p class="mt-1 text-lg font-bold text-primary">{{ formatBoth(props.total, props.devise) }}</p>
+        </div>
+        <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-white/50">
+            {{ t('dashboard.daysRemainingLabel') }}
+          </p>
+          <p class="mt-1 flex items-center gap-2 text-lg font-bold" :class="urgency">
+            <span class="relative flex h-2 w-2">
+              <span
+                v-if="props.daysRemaining <= 3"
+                class="absolute inline-flex h-full w-full animate-ping rounded-full opacity-70"
+                :class="props.daysRemaining <= 0 ? 'bg-danger' : 'bg-warning'"
+              />
+              <span class="relative inline-flex h-2 w-2 rounded-full bg-current" />
+            </span>
+            {{ daysLabel }}
+          </p>
+        </div>
       </div>
+
       <div>
-        <p class="text-xs uppercase tracking-wide text-white/50">{{ t('dashboard.total') }}</p>
-        <p class="text-lg font-semibold">{{ formatBoth(props.total, props.devise) }}</p>
-      </div>
-      <div>
-        <p class="text-xs uppercase tracking-wide text-white/50">{{ t('dashboard.daysRemainingLabel') }}</p>
-        <p class="text-lg font-semibold">{{ daysLabel }}</p>
+        <div class="flex items-center justify-between text-xs font-semibold text-white/60">
+          <span>{{ t('dashboard.round', { current: props.roundIndex, total: props.totalRounds }) }}</span>
+          <span>{{ progress }}%</span>
+        </div>
+        <div class="mt-2 h-2 w-full overflow-hidden rounded-full bg-white/5">
+          <div
+            class="h-full rounded-full bg-gradient-to-r from-primary via-primarySoft to-primary transition-all duration-500"
+            :style="{ width: `${progress}%` }"
+          />
+        </div>
       </div>
     </div>
   </header>

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 const props = defineProps<{
-  tabs: Array<{ id: string; label: string }>;
+  tabs: Array<{ id: string; label: string; count?: number }>;
 }>();
 
 const model = defineModel<string>({ required: true });
 </script>
 
 <template>
-  <div role="tablist" class="flex flex-wrap gap-2 rounded-xl bg-white/5 p-1">
+  <div
+    role="tablist"
+    class="inline-flex w-full flex-wrap gap-1 rounded-2xl border border-white/10 bg-surface/60 p-1 backdrop-blur-sm"
+  >
     <button
       v-for="tab in props.tabs"
       :key="tab.id"
@@ -17,10 +20,21 @@ const model = defineModel<string>({ required: true });
       :aria-selected="model === tab.id"
       :tabindex="model === tab.id ? 0 : -1"
       @click="model = tab.id"
-      class="flex-1 rounded-lg px-4 py-2 text-sm font-semibold transition"
-      :class="model === tab.id ? 'bg-primary text-background shadow' : 'text-white/70 hover:text-white'"
+      class="relative flex flex-1 items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold transition-all duration-200"
+      :class="
+        model === tab.id
+          ? 'bg-primary text-background shadow-glow'
+          : 'text-white/70 hover:bg-white/5 hover:text-white'
+      "
     >
-      {{ tab.label }}
+      <span>{{ tab.label }}</span>
+      <span
+        v-if="typeof tab.count === 'number'"
+        class="rounded-full px-1.5 py-0.5 text-[10px] font-bold"
+        :class="model === tab.id ? 'bg-background/20 text-background' : 'bg-white/10 text-white/70'"
+      >
+        {{ tab.count }}
+      </span>
     </button>
   </div>
 </template>

--- a/src/pages/daret/[id].vue
+++ b/src/pages/daret/[id].vue
@@ -116,8 +116,8 @@ function downloadCalendar() {
     <Tabs
       v-model="tabs"
       :tabs="[
-        { id: 'payments', label: t('dashboard.payments') },
-        { id: 'history', label: t('dashboard.history') },
+        { id: 'payments', label: t('dashboard.payments'), count: paymentsForActive.length },
+        { id: 'history', label: t('dashboard.history'), count: daret.rounds.length },
       ]"
     />
 
@@ -138,6 +138,9 @@ function downloadCalendar() {
           {{ t('actions.closeRound') }}
         </BaseButton>
         <BaseButton type="button" variant="secondary" @click="downloadCalendar">
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M6 2a1 1 0 011 1v1h6V3a1 1 0 112 0v1h1a2 2 0 012 2v10a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 011-1zm10 6H4v8h12V8zM9 11a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd" />
+          </svg>
           {{ t('actions.downloadIcs') }}
         </BaseButton>
         <BaseButton
@@ -146,6 +149,9 @@ function downloadCalendar() {
           variant="ghost"
           @click="toggleNotificationPermission"
         >
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+          </svg>
           {{ t('notifications.enable') }}
         </BaseButton>
       </div>
@@ -153,17 +159,27 @@ function downloadCalendar() {
 
     <section v-if="tabs === 'history'" class="card space-y-4">
       <h3 class="text-lg font-semibold">{{ t('dashboard.history') }}</h3>
-      <ul v-if="daret.rounds.length" class="space-y-3">
-        <li v-for="round in daret.rounds" :key="round.index" class="flex items-center justify-between gap-4">
-          <div>
-            <p class="font-semibold">{{ t('dashboard.round', { current: round.index, total: daret.rounds.length }) }}</p>
-            <p class="text-xs text-white/60">{{ formatDate(round.dateDebut, locale) }} → {{ formatDate(round.dateFin, locale) }}</p>
+      <ul v-if="daret.rounds.length" class="space-y-2">
+        <li
+          v-for="round in daret.rounds"
+          :key="round.index"
+          class="flex items-center justify-between gap-4 rounded-xl border border-white/5 bg-surface/40 p-4 transition-colors hover:border-white/15"
+        >
+          <div class="flex items-center gap-3">
+            <span
+              class="flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold"
+              :class="round.clos ? 'bg-success/20 text-successSoft' : 'bg-primary/15 text-primary'"
+            >
+              {{ round.index }}
+            </span>
+            <div>
+              <p class="font-semibold">{{ t('dashboard.round', { current: round.index, total: daret.rounds.length }) }}</p>
+              <p class="text-xs text-white/55">{{ formatDate(round.dateDebut, locale) }} → {{ formatDate(round.dateFin, locale) }}</p>
+            </div>
           </div>
           <div class="text-right text-sm text-white/70">
-            <p>{{ daret.membres.find((membre) => membre.id === round.receveurId)?.nom }}</p>
-            <PaymentStatusBadge
-              :statut="round.clos ? 'paye' : 'a_payer'"
-            />
+            <p class="font-medium text-white">{{ daret.membres.find((membre) => membre.id === round.receveurId)?.nom }}</p>
+            <PaymentStatusBadge :statut="round.clos ? 'paye' : 'a_payer'" />
           </div>
         </li>
       </ul>
@@ -171,28 +187,81 @@ function downloadCalendar() {
     </section>
 
     <section class="card space-y-4">
-      <h3 class="text-lg font-semibold">{{ t('dashboard.roster') }}</h3>
+      <h3 class="flex items-center gap-2 text-lg font-semibold">
+        <svg class="h-5 w-5 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+        </svg>
+        {{ t('dashboard.roster') }}
+      </h3>
       <ul class="grid gap-2 sm:grid-cols-2">
-        <li v-for="(memberId, index) in daret.roster" :key="memberId" class="rounded-lg bg-white/5 px-4 py-3">
-          <p class="font-semibold">{{ index + 1 }}. {{ daret.membres.find((membre) => membre.id === memberId)?.nom }}</p>
+        <li
+          v-for="(memberId, index) in daret.roster"
+          :key="memberId"
+          class="flex items-center gap-3 rounded-xl border border-white/5 bg-white/5 px-4 py-3 transition-colors hover:border-primary/30"
+        >
+          <span class="flex h-8 w-8 items-center justify-center rounded-full bg-primary/15 text-xs font-bold text-primary ring-1 ring-inset ring-primary/25">
+            {{ index + 1 }}
+          </span>
+          <p class="truncate font-semibold">{{ daret.membres.find((membre) => membre.id === memberId)?.nom }}</p>
         </li>
       </ul>
     </section>
 
     <InviteBanner v-if="inviteLink" :invitation-url="inviteLink" />
 
-    <section class="card space-y-2">
-      <h3 class="text-lg font-semibold">Stats</h3>
-      <p class="text-sm text-white/70">
-        {{ t('dashboard.payments') }} : {{ completionPercentage(paymentsForActive) }}% ·
-        {{ t('dashboard.late') }} : {{ countByStatut(paymentsForActive, 'retard') }}
-      </p>
+    <section class="card">
+      <h3 class="flex items-center gap-2 text-lg font-semibold">
+        <svg class="h-5 w-5 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        </svg>
+        Statistiques
+      </h3>
+      <div class="mt-4 grid gap-3 sm:grid-cols-2">
+        <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+          <p class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('dashboard.payments') }}</p>
+          <div class="mt-2 flex items-baseline gap-2">
+            <p class="text-3xl font-bold text-primary">{{ completionPercentage(paymentsForActive) }}%</p>
+            <p class="text-xs text-white/60">complétion</p>
+          </div>
+          <div class="mt-3 h-2 overflow-hidden rounded-full bg-white/5">
+            <div
+              class="h-full rounded-full bg-gradient-to-r from-primary to-primarySoft transition-all duration-500"
+              :style="{ width: `${completionPercentage(paymentsForActive)}%` }"
+            />
+          </div>
+        </div>
+        <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+          <p class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('dashboard.late') }}</p>
+          <div class="mt-2 flex items-baseline gap-2">
+            <p class="text-3xl font-bold" :class="countByStatut(paymentsForActive, 'retard') > 0 ? 'text-dangerSoft' : 'text-successSoft'">
+              {{ countByStatut(paymentsForActive, 'retard') }}
+            </p>
+            <p class="text-xs text-white/60">membre(s)</p>
+          </div>
+        </div>
+      </div>
     </section>
 
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </section>
 
-  <section v-else class="card">
-    <p class="text-sm text-white/70">Daret introuvable.</p>
+  <section v-else class="card flex flex-col items-center py-16 text-center">
+    <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-danger/15 text-dangerSoft ring-1 ring-inset ring-danger/30">
+      <svg class="h-8 w-8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+      </svg>
+    </div>
+    <h2 class="mb-2 text-xl font-semibold">Daret introuvable</h2>
+    <p class="mb-6 max-w-sm text-sm text-white/60">
+      Cette Daret n'existe pas ou a été supprimée. Consultez la liste de vos Darets ou rejoignez-en une avec un code.
+    </p>
+    <div class="flex flex-wrap justify-center gap-3">
+      <RouterLink to="/mes-darets">
+        <BaseButton variant="secondary">Mes Darets</BaseButton>
+      </RouterLink>
+      <RouterLink to="/daret/rejoindre">
+        <BaseButton variant="primary">Rejoindre</BaseButton>
+      </RouterLink>
+    </div>
   </section>
 </template>

--- a/src/pages/daret/creer.vue
+++ b/src/pages/daret/creer.vue
@@ -112,97 +112,166 @@ async function createDaret() {
 </script>
 
 <template>
-  <div class="space-y-8">
-    <Stepper :steps="steps" :current="currentStep" />
-    <p class="text-sm text-white/60">{{ t('wizard.autosave') }}</p>
+  <div class="mx-auto max-w-4xl space-y-8">
+    <header class="space-y-2">
+      <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">{{ t('wizard.summary.title') }}</h1>
+      <p class="text-sm text-white/60">{{ t('wizard.review') }}</p>
+    </header>
+
+    <div class="card-interactive">
+      <Stepper :steps="steps" :current="currentStep" />
+      <p class="mt-4 inline-flex items-center gap-2 text-xs text-white/50">
+        <svg class="h-3.5 w-3.5 text-primary" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+        </svg>
+        {{ t('wizard.autosave') }}
+      </p>
+    </div>
 
     <form class="space-y-6" @submit.prevent="createDaret">
-      <section v-if="currentStep === 0" class="card space-y-4">
-        <BaseInput id="nom" v-model="state.values.nom" :label="t('form.name')" :error="state.errors.nom" required />
-        <BaseInput id="description" v-model="state.values.description" :label="t('form.description')" />
-        <div class="grid gap-4 sm:grid-cols-2">
-          <BaseInput
-            id="montant"
-            v-model.number="state.values.montantMensuel"
-            type="number"
-            :label="t('form.amount')"
-            min="10"
-            :error="state.errors.montantMensuel"
-          />
-          <BaseInput
-            id="taille"
-            v-model.number="state.values.taille"
-            type="number"
-            :label="t('form.size')"
-            min="2"
-            max="50"
-            :error="state.errors.taille"
-          />
+      <Transition
+        enter-active-class="transition duration-300 ease-out"
+        enter-from-class="opacity-0 translate-y-2"
+        enter-to-class="opacity-100 translate-y-0"
+        mode="out-in"
+      >
+        <section v-if="currentStep === 0" key="step-0" class="card space-y-5">
+          <div>
+            <h2 class="text-xl font-semibold">{{ t('wizard.step1') }}</h2>
+            <p class="mt-1 text-sm text-white/60">Nom, montant, devise et dates clés de votre Daret.</p>
+          </div>
+          <BaseInput id="nom" v-model="state.values.nom" :label="t('form.name')" :error="state.errors.nom" required placeholder="Ex. Daret famille Casa" />
+          <BaseInput id="description" v-model="state.values.description" :label="t('form.description')" placeholder="Quelques mots pour présenter cette Daret" />
+          <div class="grid gap-4 sm:grid-cols-2">
+            <BaseInput
+              id="montant"
+              v-model.number="state.values.montantMensuel"
+              type="number"
+              :label="t('form.amount')"
+              min="10"
+              :error="state.errors.montantMensuel"
+            />
+            <BaseInput
+              id="taille"
+              v-model.number="state.values.taille"
+              type="number"
+              :label="t('form.size')"
+              min="2"
+              max="50"
+              :error="state.errors.taille"
+            />
+            <BaseSelect
+              id="devise"
+              v-model="state.values.devise"
+              :label="t('form.currency')"
+              :options="[
+                { label: 'MAD (DH)', value: 'MAD' },
+                { label: 'EUR (€)', value: 'EUR' },
+              ]"
+            />
+            <BaseInput
+              id="dateDebut"
+              v-model="state.values.dateDebut"
+              type="date"
+              :label="t('form.startDate')"
+              :error="state.errors.dateDebut"
+            />
+          </div>
           <BaseSelect
-            id="devise"
-            v-model="state.values.devise"
-            :label="t('form.currency')"
+            id="visibilite"
+            v-model="state.values.visibilite"
+            :label="t('form.visibility')"
             :options="[
-              { label: 'MAD', value: 'MAD' },
-              { label: 'EUR', value: 'EUR' },
+              { label: t('form.visibilityOptions.privee'), value: 'privee' },
+              { label: t('form.visibilityOptions.non-listee'), value: 'non-listee' },
+              { label: t('form.visibilityOptions.publique'), value: 'publique' },
             ]"
           />
+        </section>
+
+        <section v-else-if="currentStep === 1" key="step-1" class="space-y-4">
+          <div class="card space-y-1.5">
+            <h2 class="text-xl font-semibold">{{ t('wizard.step2') }}</h2>
+            <p class="text-sm text-white/60">Ajoutez les membres et réglez l'ordre de tirage.</p>
+          </div>
+          <RosterEditor v-model="state.values.membres" :seed="seedStorage" @update:seed="(seed) => (seedStorage.value = seed)" />
+          <p v-if="!state.values.membres.length" class="text-sm text-white/60">{{ t('wizard.emptyRoster') }}</p>
+          <p v-if="state.errors.roster" class="text-sm text-dangerSoft">{{ state.errors.roster }}</p>
+        </section>
+
+        <section v-else-if="currentStep === 2" key="step-2" class="card space-y-6">
+          <div>
+            <h2 class="text-xl font-semibold">{{ t('wizard.step3') }}</h2>
+            <p class="mt-1 text-sm text-white/60">Délai de grâce et rappels de paiement.</p>
+          </div>
           <BaseInput
-            id="dateDebut"
-            v-model="state.values.dateDebut"
-            type="date"
-            :label="t('form.startDate')"
-            :error="state.errors.dateDebut"
+            id="delai"
+            v-model.number="state.values.regles.delaiGraceJours"
+            type="number"
+            :label="t('form.gracePeriod')"
+            min="0"
+            max="30"
+            hint="Nombre de jours tolérés après l'échéance avant qu'un paiement soit noté en retard."
           />
-        </div>
-        <BaseSelect
-          id="visibilite"
-          v-model="state.values.visibilite"
-          :label="t('form.visibility')"
-          :options="[
-            { label: t('form.visibilityOptions.privee'), value: 'privee' },
-            { label: t('form.visibilityOptions.non-listee'), value: 'non-listee' },
-            { label: t('form.visibilityOptions.publique'), value: 'publique' },
-          ]"
-        />
-      </section>
+          <label
+            class="flex cursor-pointer items-start gap-3 rounded-xl border border-white/10 bg-surface/50 p-4 transition-colors hover:border-primary/30 hover:bg-surface/70"
+            :class="state.values.regles.rappelLocal ? 'border-primary/40 bg-primary/5' : ''"
+          >
+            <input
+              v-model="state.values.regles.rappelLocal"
+              type="checkbox"
+              class="mt-0.5 h-4 w-4 flex-shrink-0 rounded border-white/20 bg-surface text-primary focus:ring-2 focus:ring-primary/40"
+            />
+            <div>
+              <span class="block text-sm font-semibold text-white">{{ t('form.localReminders') }}</span>
+              <span class="mt-0.5 block text-xs text-white/60">
+                Reçoit des notifications navigateur le jour de l'échéance (avec votre accord).
+              </span>
+            </div>
+          </label>
+        </section>
 
-      <section v-if="currentStep === 1" class="space-y-4">
-        <RosterEditor v-model="state.values.membres" :seed="seedStorage" @update:seed="(seed) => (seedStorage.value = seed)" />
-        <p v-if="!state.values.membres.length" class="text-sm text-white/60">{{ t('wizard.emptyRoster') }}</p>
-        <p v-if="state.errors.roster" class="text-sm text-danger">{{ state.errors.roster }}</p>
-      </section>
+        <section v-else-if="currentStep === 3" key="step-3" class="card space-y-5">
+          <div>
+            <h2 class="text-xl font-semibold">{{ t('wizard.step4') }}</h2>
+            <p class="mt-1 text-sm text-white/60">Vérifiez les informations avant de créer votre Daret.</p>
+          </div>
+          <dl class="grid gap-3 sm:grid-cols-2">
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('form.name') }}</dt>
+              <dd class="mt-1 truncate font-semibold text-white">{{ state.values.nom || '—' }}</dd>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('form.amount') }}</dt>
+              <dd class="mt-1 font-semibold text-primary">
+                {{ state.values.montantMensuel }} {{ state.values.devise }}
+              </dd>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('form.size') }}</dt>
+              <dd class="mt-1 font-semibold text-white">{{ state.values.taille }} membres</dd>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('form.startDate') }}</dt>
+              <dd class="mt-1 font-semibold text-white">{{ state.values.dateDebut || '—' }}</dd>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">{{ t('form.visibility') }}</dt>
+              <dd class="mt-1 font-semibold capitalize text-white">{{ state.values.visibilite }}</dd>
+            </div>
+            <div class="rounded-xl border border-white/10 bg-surface/40 p-4">
+              <dt class="text-xs font-semibold uppercase tracking-wider text-white/50">Roster</dt>
+              <dd class="mt-1 font-semibold text-white">{{ state.values.membres.length }} membres</dd>
+            </div>
+          </dl>
+        </section>
+      </Transition>
 
-      <section v-if="currentStep === 2" class="card space-y-4">
-        <BaseInput
-          id="delai"
-          v-model.number="state.values.regles.delaiGraceJours"
-          type="number"
-          :label="t('form.gracePeriod')"
-          min="0"
-          max="30"
-        />
-        <label class="flex items-center gap-2 text-sm">
-          <input v-model="state.values.regles.rappelLocal" type="checkbox" />
-          <span>{{ t('form.localReminders') }}</span>
-        </label>
-      </section>
-
-      <section v-if="currentStep === 3" class="card space-y-3">
-        <h2 class="text-xl font-semibold">{{ t('wizard.summary.title') }}</h2>
-        <p class="text-sm text-white/60">{{ t('wizard.review') }}</p>
-        <ul class="space-y-2 text-sm">
-          <li><strong>{{ t('form.name') }}:</strong> {{ state.values.nom }}</li>
-          <li><strong>{{ t('form.amount') }}:</strong> {{ state.values.montantMensuel }} {{ state.values.devise }}</li>
-          <li><strong>{{ t('form.size') }}:</strong> {{ state.values.taille }}</li>
-          <li><strong>{{ t('form.startDate') }}:</strong> {{ state.values.dateDebut || '—' }}</li>
-          <li><strong>{{ t('form.visibility') }}:</strong> {{ state.values.visibilite }}</li>
-          <li><strong>{{ t('wizard.step2') }}:</strong> {{ state.values.membres.length }} membres</li>
-        </ul>
-      </section>
-
-      <div class="flex flex-wrap justify-between gap-3">
+      <div class="flex flex-col-reverse items-stretch justify-between gap-3 sm:flex-row sm:items-center">
         <BaseButton type="button" variant="ghost" @click="previousStep" :disabled="currentStep === 0">
+          <svg class="h-4 w-4 rtl:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
+          </svg>
           {{ t('actions.previous') }}
         </BaseButton>
         <BaseButton
@@ -211,8 +280,16 @@ async function createDaret() {
           @click="nextStep"
         >
           {{ t('actions.next') }}
+          <svg class="h-4 w-4 rtl:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
+          </svg>
         </BaseButton>
-        <BaseButton v-else type="submit">{{ t('actions.create') }}</BaseButton>
+        <BaseButton v-else type="submit" size="lg">
+          <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+          </svg>
+          {{ t('actions.create') }}
+        </BaseButton>
       </div>
     </form>
 

--- a/src/pages/daret/rejoindre.vue
+++ b/src/pages/daret/rejoindre.vue
@@ -50,16 +50,46 @@ function join() {
 </script>
 
 <template>
-  <section class="mx-auto max-w-xl space-y-6">
-    <header class="space-y-2 text-center">
-      <h1 class="text-3xl font-semibold">{{ t('join.title') }}</h1>
+  <section class="mx-auto max-w-xl space-y-8 animate-fade-in-up">
+    <header class="space-y-3 text-center">
+      <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-primary ring-1 ring-inset ring-primary/30">
+        <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+        </svg>
+      </div>
+      <h1 class="text-3xl font-bold tracking-tight sm:text-4xl">{{ t('join.title') }}</h1>
       <p class="text-sm text-white/70">{{ t('join.subtitle') }}</p>
     </header>
-    <form class="card space-y-4" @submit.prevent="join">
-      <BaseInput id="code" v-model="form.code" :label="t('form.invitationCode')" required />
-      <BaseInput id="nom" v-model="form.nom" :label="t('form.memberName')" required />
-      <BaseInput id="contact" v-model="form.contact" :label="t('form.memberContact')" />
-      <BaseButton type="submit">{{ t('actions.join') }}</BaseButton>
+    <form class="card space-y-5" @submit.prevent="join">
+      <BaseInput
+        id="code"
+        v-model="form.code"
+        :label="t('form.invitationCode')"
+        hint="Le code d'invitation vous a été partagé par l'organisateur."
+        placeholder="ABC-123"
+        required
+        autocapitalize="characters"
+      />
+      <BaseInput
+        id="nom"
+        v-model="form.nom"
+        :label="t('form.memberName')"
+        placeholder="Votre nom complet"
+        required
+      />
+      <BaseInput
+        id="contact"
+        v-model="form.contact"
+        :label="t('form.memberContact')"
+        placeholder="Email ou téléphone (optionnel)"
+        hint="Facilite les rappels si l'organisateur les active."
+      />
+      <BaseButton type="submit" block size="lg">
+        {{ t('actions.join') }}
+        <svg class="h-4 w-4 rtl:rotate-180" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+      </BaseButton>
     </form>
     <Toast :show="toast.show" :message="toast.message" :type="toast.type" />
   </section>


### PR DESCRIPTION
## Summary

Second UI/UX pass on the screens not covered by #13.

### Components
- **RoundHeader**: initials avatar, animated gradient progress bar, urgency-colored days remaining with pulse dot, ringed stat cards.
- **Tabs**: surface-backed rounded container, active pill uses primary glow, optional numeric count chip.
- **ContributionGrid**: member avatar, softer hover, the action button matching the current status is promoted (primary for paid, danger for late).
- **InviteBanner**: iconified heading, framed URL chip, copy button toggles to primary with check icon, optional native share button, cleaner QR frame.

### Pages
- **Dashboard (`daret/[id].vue`)**: tabs with counters, rich history rows (round chip + status), full Stats card with completion progress bar and late indicator, upgraded "Daret introuvable" empty state with CTAs.
- **Wizard (`daret/creer.vue`)**: page heading, autosave chip with check icon, smooth per-step transition, context subtitles, summary as 2-col cards, arrow icons on next/previous, reminders toggle styled as a selectable card.
- **Join (`daret/rejoindre.vue`)**: icon header, helpful hints/placeholders on inputs, full-width submit with arrow icon.

## Test plan
- [x] `npm run test:run` — 27/27 passing
- [x] `VITE_BASE_URL=/Tonti/ npm run build` — clean build
- [ ] Post-merge: Deploy Pages workflow green at https://naciro2010.github.io/Tonti/
